### PR TITLE
Restore CI/publish workflows in the public repo

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,28 @@
+name: deploy-docs
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: ~/.cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs mkdocs-material mkdocs-autorefs "mkdocstrings[python]"
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,43 @@
+# This build is purely for CI. The built images are not pushed anywhere.
+name: "CI: Docker Compose Build"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build containers
+        run: docker compose build
+        env:
+          # These all need to be set for the build.
+          GOOGLE_APPLICATION_CREDENTIALS: /dev/null
+          GCS_BUCKET: ""
+          GCP_PROJECT: ""
+          GOOGLE_ACCESS_KEY_ID: ""
+          GOOGLE_ACCESS_KEY_SECRET: ""
+
+      - name: Notify Slack on failure
+        if: ${{ failure() && github.ref == 'refs/heads/main' && env.SLACK_WEBHOOK_URL != '' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "🚨 CI: Docker Compose Build failed\nAuthor: ${{ github.actor }}\nWorkflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,60 @@
+name: Publish to PyPI
+# See https://docs.pypi.org/trusted-publishers/ for how this is authenticated
+
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g., v0.1.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write  # Required for trusted publishing
+      contents: read   # Required to checkout the repo
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Build asta-autodiscovery-modal
+        run: uv build --package asta-autodiscovery-modal --out-dir dist/asta-autodiscovery-modal
+
+      - name: Publish asta-autodiscovery-modal to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/asta-autodiscovery-modal
+          print-hash: true
+
+      - name: Build asta-code-execution
+        run: uv build --package asta-code-execution --out-dir dist/asta-code-execution
+
+      - name: Publish asta-code-execution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/asta-code-execution
+          print-hash: true
+
+      - name: Build asta-autodiscovery
+        run: uv build --package asta-autodiscovery --out-dir dist/asta-autodiscovery
+
+      - name: Publish asta-autodiscovery to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/asta-autodiscovery
+          print-hash: true
+

--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -1,0 +1,47 @@
+# This build is purely for CI. It does not publish any artifacts.
+name: "CI: UI Build"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+    defaults:
+      run:
+        working-directory: ui
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "yarn"
+          cache-dependency-path: ui/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build project
+        run: yarn build
+
+      - name: Notify Slack on failure
+        if: ${{ failure() && github.ref == 'refs/heads/main' && env.SLACK_WEBHOOK_URL != '' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "🚨 CI: UI Build failed\nAuthor: ${{ github.actor }}\nWorkflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/ui/src/app/components/AstaAdBanner.tsx
+++ b/ui/src/app/components/AstaAdBanner.tsx
@@ -47,7 +47,7 @@ export const AstaAdBanner = ({ isFullWidth = false }: AstaAdBannerProps) => {
 
     return (
         <Box
-            onClick={() => window.open('https://asta.example.com?utm_source=AutoDiscovery', '_blank')}
+            onClick={() => window.open('https://asta.allen.ai?utm_source=AutoDiscovery', '_blank')}
             sx={{
                 position: 'fixed',
                 bottom: showBanner ? '0' : '-200px',

--- a/ui/src/app/runs/page.tsx
+++ b/ui/src/app/runs/page.tsx
@@ -54,7 +54,7 @@ export default function RunsPage() {
                             </Ai2LogoWrapper>{' '}
                             and is an{' '}
                             <AstaLabsLogoWrapper
-                                href="https://asta.example.com"
+                                href="https://asta.allen.ai"
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 data-test-id={TEST_ID_ASTA_LABS_LOGO_LINK}>


### PR DESCRIPTION
## What

Re-adds the four GitHub Actions that **validate or publish the OSS code itself**, so they live with the code in the public repo:

| Workflow | Trigger | Purpose |
|---|---|---|
| **CI: UI Build** | PR + push to main | `yarn build` / type-check |
| **CI: Docker Compose Build** | PR + push to main | `docker compose build` (no push) |
| **deploy-docs** | push to main | `mkdocs gh-deploy` → GitHub Pages |
| **Publish to PyPI** | manual `workflow_dispatch` | publish `asta-autodiscovery`, `asta-code-execution`, `asta-autodiscovery-modal` |

These were removed in `e18c03f` ("Remove github workflows for the moment"). This restores the already-scrubbed versions from that commit's parent.

## Note on the Slack guard

The failure-notify steps in the two CI builds now also gate on `env.SLACK_WEBHOOK_URL != ''`, so they cleanly no-op in any repo/fork where that secret isn't configured (and they already only fired on `failure()` on `main`).

## Expected on this PR

`CI: UI Build` and `CI: Docker Compose Build` run on the `pull_request` event and should go green. `deploy-docs` only runs on push to `main` (after merge); `Publish to PyPI` is manual and is intentionally **not** triggered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)