### PR TITLE
Apply Apache 2.0 license to the repository

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Asta AutoDiscovery
+Copyright 2026 The Allen Institute for Artificial Intelligence (Ai2)
+
+This product includes software developed at
+The Allen Institute for Artificial Intelligence (https://allenai.org/).

--- a/README.md
+++ b/README.md
@@ -121,3 +121,7 @@ You can find more details about your application via [Marina](https://deploy.exa
 ## Getting Help
 
 See [Skiff's Documentation](https://***REMOVED***/) for more information.
+
+## License
+
+This project is licensed under the Apache License, Version 2.0. See the [LICENSE](LICENSE) and [NOTICE](NOTICE) files for details.

--- a/packages/agents/pyproject.toml
+++ b/packages/agents/pyproject.toml
@@ -3,6 +3,7 @@ name = "asta-agents"
 version = "0.1.5"
 description = "Add your description here"
 readme = "README.md"
+license = "Apache-2.0"
 authors = [
     { name = "Allen Institute for Artificial Intelligence" }
 ]

--- a/packages/autodiscovery/pyproject.toml
+++ b/packages/autodiscovery/pyproject.toml
@@ -3,6 +3,7 @@ name = "asta-autodiscovery"
 version = "0.1.5"
 description = "Open-ended Scientific Discovery via Bayesian Surprise"
 readme = "README.md"
+license = "Apache-2.0"
 requires-python = ">=3.13"
 dependencies = [
     "pip",

--- a/packages/autodiscovery_jobs/pyproject.toml
+++ b/packages/autodiscovery_jobs/pyproject.toml
@@ -3,6 +3,7 @@ name = "asta-autodiscovery-jobs"
 version = "0.1.5"
 description = "Python package for managing Cloud Run jobs with GCS integration"
 readme = "README.md"
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "google-cloud-storage>=2.14.0",

--- a/packages/autodiscovery_modal/pyproject.toml
+++ b/packages/autodiscovery_modal/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 requires-python = ">=3.13"
 dependencies = [
-    "asta-sandbox[modal-ephemeral]==0.1.2",
+    "asta-sandbox[modal-ephemeral]==0.1.3",
     "modal>=1.2.6",
 ]
 

--- a/packages/autodiscovery_modal/pyproject.toml
+++ b/packages/autodiscovery_modal/pyproject.toml
@@ -3,6 +3,7 @@ name = "asta-autodiscovery-modal"
 version = "0.1.5"
 description = "Add your description here"
 readme = "README.md"
+license = "Apache-2.0"
 authors = [
     { name = "Allen Institute for Artificial Intelligence" }
 ]

--- a/packages/code_execution/pyproject.toml
+++ b/packages/code_execution/pyproject.toml
@@ -3,6 +3,7 @@ name = "asta-code-execution"
 version = "0.1.5"
 description = "Add your description here"
 readme = "README.md"
+license = "Apache-2.0"
 authors = [
     { name = "Allen Institute for Artificial Intelligence" }
 ]

--- a/packages/devtools/pyproject.toml
+++ b/packages/devtools/pyproject.toml
@@ -3,6 +3,7 @@ name = "asta-devtools"
 version = "0.1.5"
 description = "Developer tooling for AutoDiscovery"
 readme = "README.md"
+license = "Apache-2.0"
 authors = [
     { name = "Allen Institute for Artificial Intelligence" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "asta-autodiscovery-workspace"
 version = "0.1.5"
 description = "Asta AutoDiscovery (workspace root)"
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [
     { name = "Allen Institute for Artificial Intelligence" }
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asta-sandbox", extras = ["modal-ephemeral"], specifier = "==0.1.2" },
+    { name = "asta-sandbox", extras = ["modal-ephemeral"], specifier = "==0.1.3" },
     { name = "modal", specifier = ">=1.2.6" },
 ]
 
@@ -376,14 +376,14 @@ provides-extras = ["cli"]
 
 [[package]]
 name = "asta-sandbox"
-version = "0.1.2"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ipython" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/05/d870bd28fea8688bca8322cb6e2a1cf075279d4557d51589517752c7af00/asta_sandbox-0.1.2.tar.gz", hash = "sha256:746911311b09921a77dec5fc51685bf22a1ae6d44e2e3d91e7aca2c12dd73970", size = 20801, upload-time = "2026-05-12T21:58:45.581Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/8f/c0fb2b579a8c8c596e91bcf4cedc77cc33b29c34a3c0314325e66dfde621/asta_sandbox-0.1.3.tar.gz", hash = "sha256:7dbf0c8f62d41053dd7db3cad4e4fef921d43800cea9227554e691bf27d77753", size = 24749, upload-time = "2026-06-08T23:52:12.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/12/290e5b5bd85036bb5b903cfed14127156180bdf463a70317e04750305da0/asta_sandbox-0.1.2-py3-none-any.whl", hash = "sha256:24735e585f95ef30ead6cde94ae620f1a220d54bb426e55dfe725f6feb72b100", size = 29141, upload-time = "2026-05-12T21:58:44.302Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/4a/81cf79c318ac762d931bbb2785dd943fedd8a4e674588b8134683bf0c306/asta_sandbox-0.1.3-py3-none-any.whl", hash = "sha256:4b0596d70517230fb6bd0ee3c8373edc442ded0fb555f3a7468126eb9d0f0783", size = 33496, upload-time = "2026-06-08T23:52:11.827Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Marks this repository as Apache 2.0 ahead of open-sourcing.

## Changes
- **`LICENSE`** — verbatim Apache License 2.0 text (fetched from apache.org).
- **`NOTICE`** — Apache 2.0 attribution notice crediting Ai2.
- **`pyproject.toml`** (workspace root) — declares `license = "Apache-2.0"` (SPDX, PEP 639) and `license-files = ["LICENSE"]`.
- **`packages/*/pyproject.toml`** — each of the 6 member packages declares `license = "Apache-2.0"`.
- **`README.md`** — adds a License section.

## Notes
- Apache 2.0 is Ai2's default code license, so no alternative-license justification is needed.
- `uv lock --check` still resolves cleanly after the metadata changes.
- This is the licensing step only; documentation scrub, the private-dependency (`asta-sandbox`) work, and the Legal/IT dependency review are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)