### PR TITLE
Make e2e sign-in auth domain configurable via E2E_AUTH_DOMAIN

### DIFF
--- a/ui/e2e/details-pages.spec.ts
+++ b/ui/e2e/details-pages.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { expectExternalLink, waitForExperimentsLoaded } from './helpers';
+import { expectExternalLink, waitForExperimentsLoaded, AUTH_DOMAIN } from './helpers';
 import {
     TEST_ID_SIGN_IN_BUTTON,
     TEST_ID_FEEDBACK_BUTTON,
@@ -62,17 +62,17 @@ for (const url of DETAILS_URLS) {
             ).toBeVisible({ timeout: 60000 });
         });
 
-        test('sign in button links to auth.example.com', async ({ page }) => {
+        test('sign in button links to the auth domain', async ({ page }) => {
             const signInBtn = page.locator(`[data-test-id="${TEST_ID_SIGN_IN_BUTTON}"]`);
             await expect(signInBtn).toBeVisible();
 
             const requestPromise = page.waitForRequest(
-                (req) => req.url().includes('auth.example.com'),
+                (req) => req.url().includes(AUTH_DOMAIN),
                 { timeout: 20000 }
             );
             await signInBtn.click();
             const request = await requestPromise;
-            expect(request.url()).toContain('auth.example.com');
+            expect(request.url()).toContain(AUTH_DOMAIN);
         });
 
         test('feedback button opens page without error', async ({ page, context }) => {

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -1,6 +1,13 @@
 import { Page, BrowserContext, expect } from '@playwright/test';
 
 /**
+ * Auth provider domain the sign-in button redirects to. Configurable via the
+ * E2E_AUTH_DOMAIN env var (set per-environment in CI); falls back to a generic
+ * placeholder for the public repo.
+ */
+export const AUTH_DOMAIN = process.env.E2E_AUTH_DOMAIN || 'auth.example.com';
+
+/**
  * Clicks an element and asserts the outgoing navigation request goes to a URL
  * containing the given domain. Intercepts the request before it completes so
  * the test page is not navigated away from.

--- a/ui/e2e/homepage.spec.ts
+++ b/ui/e2e/homepage.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { expectExternalLink } from './helpers';
+import { expectExternalLink, AUTH_DOMAIN } from './helpers';
 import {
     TEST_ID_SIGN_IN_BUTTON,
     TEST_ID_FEEDBACK_BUTTON,
@@ -32,18 +32,18 @@ test.describe('Homepage (/runs)', () => {
         await expect(page.locator('.MuiAlert-filledError')).toHaveCount(0);
     });
 
-    test('sign in button links to auth.example.com domain', async ({ page }) => {
+    test('sign in button links to the auth domain', async ({ page }) => {
         const signInBtn = page.locator(`[data-test-id="${TEST_ID_SIGN_IN_BUTTON}"]`);
         await expect(signInBtn).toBeVisible();
 
         // Intercept navigation to auth0 before it completes
         const requestPromise = page.waitForRequest(
-            (req) => req.url().includes('auth.example.com'),
+            (req) => req.url().includes(AUTH_DOMAIN),
             { timeout: 10000 }
         );
         await signInBtn.click();
         const request = await requestPromise;
-        expect(request.url()).toContain('auth.example.com');
+        expect(request.url()).toContain(AUTH_DOMAIN);
     });
 
     test('feedback button links to a page that does not error out', async ({ page, context }) => {

--- a/ui/e2e/runs-pages.spec.ts
+++ b/ui/e2e/runs-pages.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { expectExternalLink, waitForExperimentsLoaded } from './helpers';
+import { expectExternalLink, waitForExperimentsLoaded, AUTH_DOMAIN } from './helpers';
 import {
     TEST_ID_SIGN_IN_BUTTON,
     TEST_ID_FEEDBACK_BUTTON,
@@ -73,17 +73,17 @@ for (const url of RUN_URLS) {
             await expect(page).toHaveURL(/\/runs$/);
         });
 
-        test('sign in button links to auth.example.com', async ({ page }) => {
+        test('sign in button links to the auth domain', async ({ page }) => {
             const signInBtn = page.locator(`[data-test-id="${TEST_ID_SIGN_IN_BUTTON}"]`);
             await expect(signInBtn).toBeVisible();
 
             const requestPromise = page.waitForRequest(
-                (req) => req.url().includes('auth.example.com'),
+                (req) => req.url().includes(AUTH_DOMAIN),
                 { timeout: 10000 }
             );
             await signInBtn.click();
             const request = await requestPromise;
-            expect(request.url()).toContain('auth.example.com');
+            expect(request.url()).toContain(AUTH_DOMAIN);
         });
 
         test('feedback button opens page without error', async ({ page, context }) => {


### PR DESCRIPTION
## What

The e2e sign-in tests asserted the sign-in button redirects to a hardcoded auth provider domain. When the suite runs against a real deployment (whose auth domain differs from the placeholder baked into this repo), `waitForRequest(...)` never matches and the tests time out.

This makes the domain configurable via a new `E2E_AUTH_DOMAIN` env var, read in `ui/e2e/helpers.ts` (`AUTH_DOMAIN`) and used by the three sign-in specs. It falls back to the existing placeholder when the var is unset, so the public repo stays scrubbed; CI injects the real value (alongside the existing `E2E_BASE_URL` / `E2E_TEST_*` vars).

## Changes
- `ui/e2e/helpers.ts` — export `AUTH_DOMAIN = process.env.E2E_AUTH_DOMAIN || 'auth.example.com'`
- `ui/e2e/{homepage,runs-pages,details-pages}.spec.ts` — use `AUTH_DOMAIN`; generalize the test titles

## Note
Requires the consuming repo's e2e workflow to set `E2E_AUTH_DOMAIN` to the deployment's real auth domain (handled separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)