### PR TITLE
For GCP creds bind - create_host_path false

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,12 @@ services:
       - .env
     volumes:
       - ./api:/api
-      - ${GOOGLE_APPLICATION_CREDENTIALS}:/secrets/gcp-key.json:ro
+      - type: bind
+        source: ${GOOGLE_APPLICATION_CREDENTIALS}
+        target: /secrets/gcp-key.json
+        read_only: true
+        bind:
+          create_host_path: false
     environment:
       # This ensures that errors are printed as they occur, which
       # makes debugging easier.


### PR DESCRIPTION
In a fresh project checkout if this isn't set exactly right the first time, docker compose will generate a source folder to mount in the created container. Then when the developer fixes the creds file and starts the stack again, the compose stack will refuse to start because source is now a file but target is a folder.

Here's what the error looks like now instead of docker compose automatically creating a folder in the container.
```
[+] Running 5/6
 ✔ public-ui               Built                                                                                                                                                                                                             0.0s
 ✔ public-api              Built                                                                                                                                                                                                             0.0s
 ✔ public-proxy            Built                                                                                                                                                                                                             0.0s
 ✔ public-sonar            Built                                                                                                                                                                                                             0.0s
 ✘ Container public-api-1  Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /host_mnt/Users/jasond/ai2/asta-autodiscovery-private/public/secrets/ai2-autodisco...                          0.0s
 ⠋ Container public-ui-1   Recreate                                                                                                                                                                                                          0.0s
Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /host_mnt/Users/jasond/ai2/asta-autodiscovery-private/public/secrets/ai2-autodiscovery-sa.json
```