### PR TITLE
Gate New Asta Features

### DIFF
--- a/api/runs/models.py
+++ b/api/runs/models.py
@@ -251,6 +251,7 @@ class RunModel(BaseModel):
     run_metadata: MetadataModel | None = Field(None, description="Metadata associated with the run")
     max_file_size: str | None = Field(None, description="Maximum file size limit for uploads, if applicable")
     can_view_datasets: bool = Field(False, description="Bool flag determining if AI1 datasets are visible")
+    can_explore_with_asta: bool = Field(False, description="Bool flag determining if Asta exploration features are visible")
     parent_run_id: str | None = Field(None, description="ID of the parent run this was forked from")
     parent_run_name: str | None = Field(None, description="Name of the parent run")
     dataset_expires_at: str | None = Field(

--- a/api/runs/runs_api.py
+++ b/api/runs/runs_api.py
@@ -605,8 +605,9 @@ def create() -> Blueprint:
             has_higher_upload_limit = PermissionType.HIGHER_UPLOAD_LIMIT.value in permissions
             max_file_size = UPLOAD_MAX_FILE_SIZE_HIGHER_LIMIT_STR if has_higher_upload_limit else None
 
-            # Check if user has AI1_DATASETS permission for dataset access in the UI
+            # Check if user has permission for access in the UI
             has_ai1_datasets = PermissionType.AI1_DATASETS.value in permissions
+            has_asta_integration = PermissionType.ASTA_INTEGRATION.value in permissions
 
             # Compute dataset expiry
             dataset_expires_at = _compute_dataset_expires_at(run_details)
@@ -624,6 +625,7 @@ def create() -> Blueprint:
                 execution_status={},
                 max_file_size=max_file_size,
                 can_view_datasets=has_ai1_datasets,
+                can_explore_with_asta=has_asta_integration,
                 parent_run_id=(
                     run_metadata_model.parent_run_id if run_metadata_model else None
                 ),

--- a/api/utils/asta_client.py
+++ b/api/utils/asta_client.py
@@ -7,7 +7,7 @@ import requests
 
 _log = logging.getLogger("api.asta_client")
 
-ASTA_BASE_URL = os.environ.get("ASTA_BASE_URL", "https://asta-rc.allen.ai")
+ASTA_BASE_URL = os.environ.get("ASTA_BASE_URL", "https://asta.allen.ai")
 
 
 def login_or_create_user(

--- a/api/utils/auth.py
+++ b/api/utils/auth.py
@@ -18,6 +18,7 @@ class PermissionType(Enum):
     ADMIN = "enroll:autodiscovery_admin"
     HIGHER_UPLOAD_LIMIT = "enroll:higher_upload_limit"
     AI1_DATASETS = "enroll:ai1_datasets"
+    ASTA_INTEGRATION= "enroll:asta_integration"
 
 
 def get_public_key(auth0_domain, kid):

--- a/ui/src/app/api/RunsApi.ts
+++ b/ui/src/app/api/RunsApi.ts
@@ -63,6 +63,7 @@ export interface RunFromApi {
     parent_run_id?: string | null;
     parent_run_name?: string | null;
     dataset_expires_at?: string | null;
+    can_explore_with_asta?: boolean;
 }
 
 export interface UploadDatasetResponseBody {
@@ -80,6 +81,7 @@ export interface GenerateUploadUrlResponseBody {
 
 export interface RunResponseBody extends RunFromApi {
     can_view_datasets: boolean;
+    can_explore_with_asta: boolean;
 }
 
 export interface GetViewerRunsResponseBody {

--- a/ui/src/app/runs/components/ExperimentDetails.tsx
+++ b/ui/src/app/runs/components/ExperimentDetails.tsx
@@ -19,6 +19,7 @@ type ExperimentDetailsProps = {
     actions?: ReactNode;
     surprisalWidth?: number | null;
     datasetExpired?: boolean;
+    canExploreWithAsta?: boolean;
 };
 
 export const ExperimentDetails = memo(function ExperimentDetails({
@@ -27,6 +28,7 @@ export const ExperimentDetails = memo(function ExperimentDetails({
     actions,
     surprisalWidth,
     datasetExpired,
+    canExploreWithAsta = false,
 }: ExperimentDetailsProps) {
     const { isLoadingSelectedExperiment, selectedExperimentError } = useRunExperiments();
     const richOutputs = experiment.richOutputs ?? [];
@@ -190,21 +192,25 @@ export const ExperimentDetails = memo(function ExperimentDetails({
                     </Box>
                 )}
             </ContentWrapper>
-            <BottomBar $visible={hasScrolled}>
-                <ContinueExploringButton
-                    variant="outlined"
-                    endIcon={datasetExpired ? undefined : <ArrowOutwardIcon />}
-                    disabled={datasetExpired}
-                    onClick={() => !datasetExpired && setIsContinueModalOpen(true)}>
-                    {datasetExpired ? 'Dataset expired' : 'Continue exploring with Asta'}
-                </ContinueExploringButton>
-            </BottomBar>
-            <ContinueWithAstaModal
-                open={isContinueModalOpen}
-                onClose={() => setIsContinueModalOpen(false)}
-                runId={runId}
-                experiment={experiment}
-            />
+            {canExploreWithAsta && (
+                <>
+                    <BottomBar $visible={hasScrolled}>
+                        <ContinueExploringButton
+                            variant="outlined"
+                            endIcon={datasetExpired ? undefined : <ArrowOutwardIcon />}
+                            disabled={datasetExpired}
+                            onClick={() => !datasetExpired && setIsContinueModalOpen(true)}>
+                            {datasetExpired ? 'Dataset expired' : 'Continue exploring with Asta'}
+                        </ContinueExploringButton>
+                    </BottomBar>
+                    <ContinueWithAstaModal
+                        open={isContinueModalOpen}
+                        onClose={() => setIsContinueModalOpen(false)}
+                        runId={runId}
+                        experiment={experiment}
+                    />
+                </>
+            )}
         </DetailsWrapper>
     );
 });

--- a/ui/src/app/runs/components/ExperimentsTable.tsx
+++ b/ui/src/app/runs/components/ExperimentsTable.tsx
@@ -237,7 +237,13 @@ export function ExperimentsTable({
         return isExperimentBookmarksEnabled
             ? visibleColumns
             : visibleColumns.filter((col) => col.field !== 'isBookmarked');
-    }, [isExperimentBookmarksEnabled, visitedIds, exploredExperimentIds, datasetExpired, canExploreWithAsta]);
+    }, [
+        isExperimentBookmarksEnabled,
+        visitedIds,
+        exploredExperimentIds,
+        datasetExpired,
+        canExploreWithAsta,
+    ]);
 
     const [sortModel, setSortModel] = useState<GridSortModel>([]);
 

--- a/ui/src/app/runs/components/ExperimentsTable.tsx
+++ b/ui/src/app/runs/components/ExperimentsTable.tsx
@@ -26,12 +26,14 @@ interface ExperimentsTableProps {
     runStats?: RunStats | null;
     surprisalWidth?: number | null;
     datasetExpired?: boolean;
+    canExploreWithAsta?: boolean;
 }
 
 export function ExperimentsTable({
     runStats,
     surprisalWidth,
     datasetExpired,
+    canExploreWithAsta = false,
 }: ExperimentsTableProps) {
     const {
         experiments,
@@ -228,13 +230,14 @@ export function ExperimentsTable({
                 },
             },
         ];
-        const visibleColumns = datasetExpired
-            ? DEFAULT_COLUMNS.filter((col) => col.field !== 'exploration')
-            : DEFAULT_COLUMNS;
+        const visibleColumns =
+            datasetExpired || !canExploreWithAsta
+                ? DEFAULT_COLUMNS.filter((col) => col.field !== 'exploration')
+                : DEFAULT_COLUMNS;
         return isExperimentBookmarksEnabled
             ? visibleColumns
             : visibleColumns.filter((col) => col.field !== 'isBookmarked');
-    }, [isExperimentBookmarksEnabled, visitedIds, exploredExperimentIds, datasetExpired]);
+    }, [isExperimentBookmarksEnabled, visitedIds, exploredExperimentIds, datasetExpired, canExploreWithAsta]);
 
     const [sortModel, setSortModel] = useState<GridSortModel>([]);
 
@@ -481,12 +484,14 @@ export function ExperimentsTable({
                     hideFooter={true}
                 />
             </Wrapper>
-            <ContinueWithAstaModal
-                open={continueExperiment !== null}
-                onClose={() => setContinueExperiment(null)}
-                runId={runid ?? ''}
-                experiment={continueExperiment}
-            />
+            {canExploreWithAsta && (
+                <ContinueWithAstaModal
+                    open={continueExperiment !== null}
+                    onClose={() => setContinueExperiment(null)}
+                    runId={runid ?? ''}
+                    experiment={continueExperiment}
+                />
+            )}
         </>
     );
 }

--- a/ui/src/app/runs/components/RunView.tsx
+++ b/ui/src/app/runs/components/RunView.tsx
@@ -285,6 +285,7 @@ function RunViewContent({
     const datasetExpired = isDatasetExpired(run.datasetExpiresAt);
     const datasetExpiryLabel = getDatasetExpiryLabel(run.datasetExpiresAt);
     const canFork = !datasetExpired && !isForking;
+    const canExploreWithAsta = run.canExploreWithAsta ?? false;
 
     const handleFork = useCallback(async () => {
         setIsForking(true);
@@ -766,6 +767,7 @@ function RunViewContent({
                             runStats={run.stats}
                             surprisalWidth={run.metadata?.surprisalWidth}
                             datasetExpired={datasetExpired}
+                            canExploreWithAsta={canExploreWithAsta}
                         />
                     </RunContent>
                     {isDragEnabled && (
@@ -801,6 +803,7 @@ function RunViewContent({
                                 runId={run.id}
                                 surprisalWidth={run.metadata?.surprisalWidth}
                                 datasetExpired={datasetExpired}
+                                canExploreWithAsta={canExploreWithAsta}
                                 actions={
                                     <>
                                         <Tooltip title="Share experiment" placement="bottom">

--- a/ui/src/app/types/Run.ts
+++ b/ui/src/app/types/Run.ts
@@ -41,6 +41,8 @@ export type Run = {
     parentRunName?: string | null;
     /** ISO date when the dataset will be deleted (typically 7 days after run creation) */
     datasetExpiresAt?: string | null;
+    /** Whether the user has permission to use Asta exploration features */
+    canExploreWithAsta?: boolean;
 };
 
 export type RunStats = {
@@ -143,6 +145,7 @@ export const getRunFromApi = (runFromApi: RunFromApi): Run => {
         parentRunId: runFromApi.parent_run_id ?? null,
         parentRunName: runFromApi.parent_run_name ?? null,
         datasetExpiresAt: runFromApi.dataset_expires_at ?? null,
+        canExploreWithAsta: runFromApi.can_explore_with_asta ?? false,
     };
 };
 


### PR DESCRIPTION
Added a new permission `enroll:asta_integration` that gates the new "explore with asta" features so that only users that have the correct permission can see them.

Tested and validated that without the permission nothing was visible, and with it I was able to see the new faetures.

I also switched to point to prod Asta since changes are now deployed there and tested to make sure everything looked good.