### PR TITLE
Refine Asta exploration UI

### DIFF
--- a/ui/src/app/runs/components/ContinueWithAstaModal.tsx
+++ b/ui/src/app/runs/components/ContinueWithAstaModal.tsx
@@ -133,7 +133,7 @@ export function ContinueWithAstaModal({
                         value={prompt}
                         onChange={(e) => setPrompt(e.target.value)}
                         variant="outlined"
-                        placeholder="Enter a follow-up question, or hypothesis to test."
+                        placeholder="Ask a follow-up question, or leave blank and Asta will suggest questions."
                     />
                 </PromptFieldGroup>
                 {error && (

--- a/ui/src/app/runs/components/ExperimentDetails.tsx
+++ b/ui/src/app/runs/components/ExperimentDetails.tsx
@@ -1,6 +1,5 @@
 import { memo, ReactNode, useEffect, useRef, useState } from 'react';
 import { styled, Typography, Box, Stack, Button } from '@mui/material';
-import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 import { Markdown } from '@allenai/varnish2/components';
 
 import { Experiment, ExperimentStatus } from '@/types/Run';
@@ -192,25 +191,33 @@ export const ExperimentDetails = memo(function ExperimentDetails({
                     </Box>
                 )}
             </ContentWrapper>
-            {canExploreWithAsta && (
-                <>
-                    <BottomBar $visible={hasScrolled}>
-                        <ContinueExploringButton
-                            variant="outlined"
-                            endIcon={datasetExpired ? undefined : <ArrowOutwardIcon />}
-                            disabled={datasetExpired}
-                            onClick={() => !datasetExpired && setIsContinueModalOpen(true)}>
-                            {datasetExpired ? 'Dataset expired' : 'Continue exploring with Asta'}
-                        </ContinueExploringButton>
-                    </BottomBar>
-                    <ContinueWithAstaModal
-                        open={isContinueModalOpen}
-                        onClose={() => setIsContinueModalOpen(false)}
-                        runId={runId}
-                        experiment={experiment}
-                    />
-                </>
-            )}
+            {canExploreWithAsta &&
+                (datasetExpired ? (
+                    <ExpiredNotice>
+                        This dataset has expired and is no longer available for exploration here.
+                        You can continue your analysis with{' '}
+                        <a href="https://asta.allen.ai" target="_blank" rel="noopener noreferrer">
+                            Asta
+                        </a>{' '}
+                        by uploading the dataset there.
+                    </ExpiredNotice>
+                ) : (
+                    <>
+                        <BottomBar $visible={hasScrolled}>
+                            <ContinueExploringButton
+                                variant="outlined"
+                                onClick={() => setIsContinueModalOpen(true)}>
+                                Continue exploring with Asta
+                            </ContinueExploringButton>
+                        </BottomBar>
+                        <ContinueWithAstaModal
+                            open={isContinueModalOpen}
+                            onClose={() => setIsContinueModalOpen(false)}
+                            runId={runId}
+                            experiment={experiment}
+                        />
+                    </>
+                ))}
         </DetailsWrapper>
     );
 });
@@ -289,16 +296,33 @@ const BottomBar = styled('div')<{ $visible: boolean }>`
     transition: transform 250ms ease-out;
 `;
 
+const ExpiredNotice = styled(Typography)`
+    margin: 0 8px 8px;
+    padding: ${({ theme }) => theme.spacing(1.5, 3)};
+    background-color: ${({ theme }) => theme.color['extra-dark-teal-100'].hex};
+    border: 1px solid ${({ theme }) => theme.color['cream-10'].rgba.toString()};
+    border-radius: 4px;
+    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.3);
+    text-align: center;
+    color: ${({ theme }) => theme.color['cream-100'].hex};
+    font-size: 0.875rem;
+
+    a {
+        color: ${({ theme }) => theme.color['green-40'].rgba.toString()};
+        text-decoration: underline;
+
+        &:hover {
+            color: ${({ theme }) => theme.color['green-100'].hex};
+        }
+    }
+`;
+
 const ContinueExploringButton = styled(Button)`
     &.MuiButton-root {
         color: ${({ theme }) => theme.color['cream-100'].hex};
         padding: ${({ theme }) => theme.spacing(0, 2)};
         height: 32px;
         white-space: nowrap;
-
-        & .MuiButton-endIcon {
-            margin-left: ${({ theme }) => theme.spacing(0.5)};
-        }
     }
 
     &.MuiButton-outlined {

--- a/ui/src/app/runs/components/ExperimentsTable.tsx
+++ b/ui/src/app/runs/components/ExperimentsTable.tsx
@@ -1,5 +1,4 @@
 import { Paper, styled, Box, Alert, Tooltip, Skeleton, GlobalStyles } from '@mui/material';
-import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 import {
     DataGrid,
     GridColDef,
@@ -224,7 +223,6 @@ export function ExperimentsTable({
                                 setContinueExperiment(params.row.experiment);
                             }}>
                             Explore with Asta
-                            <ArrowOutwardIcon />
                         </ExplorationLink>
                     );
                 },
@@ -712,9 +710,5 @@ const ExplorationLink = styled('a')`
         &:hover {
             color: ${({ theme }) => theme.color['green-40'].hex};
         }
-    }
-
-    svg {
-        font-size: 14px;
     }
 `;


### PR DESCRIPTION
This handles:

- https://github.com/allenai/nora-issues/issues/2930 - Remove external-link arrow from "Explore with Asta" table link and "Continue exploring with Asta" panel button (they open a modal, not a link)
- https://github.com/allenai/nora-issues/issues/2925 - Replace disabled "Dataset expired" button with inline notice linking to Asta for expired datasets
- https://github.com/allenai/nora-issues/issues/2940 - Update follow-up prompt placeholder copy in Continue with Asta modal

