### PR TITLE
Show experiment context in Continue with Asta modal

### DIFF
--- a/ui/src/app/runs/components/ContinueWithAstaModal.tsx
+++ b/ui/src/app/runs/components/ContinueWithAstaModal.tsx
@@ -7,9 +7,11 @@ import {
     Dialog,
     DialogContent,
     IconButton,
+    Stack,
     TextField,
     Typography,
     styled,
+    useMediaQuery,
 } from '@mui/material';
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 import CloseIcon from '@mui/icons-material/Close';
@@ -17,12 +19,14 @@ import { useEffect, useState } from 'react';
 
 import { getRunsApi } from '@/api/RunsApi';
 import { Experiment } from '@/types/Run';
+import { ExperimentContextSummary } from '@/runs/components/ExperimentContextSummary';
 
 interface ContinueWithAstaModalProps {
     open: boolean;
     onClose: () => void;
     runId: string;
     experiment?: Experiment | null;
+    surprisalWidth?: number | null;
 }
 
 const PROMPT_LABEL =
@@ -33,10 +37,12 @@ export function ContinueWithAstaModal({
     onClose,
     runId,
     experiment,
+    surprisalWidth,
 }: ContinueWithAstaModalProps) {
     const [prompt, setPrompt] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const isStacked = useMediaQuery('(max-width:700px)');
 
     useEffect(() => {
         if (!open) {
@@ -72,8 +78,14 @@ export function ContinueWithAstaModal({
             PaperProps={{
                 sx: {
                     width: '90%',
-                    maxWidth: '640px',
+                    maxWidth: experiment ? '1392px' : '640px',
                     borderRadius: '12px',
+                    // Clip the column backgrounds to the rounded corners since the
+                    // columns are now full-bleed (no padding on the content wrapper).
+                    overflow: 'hidden',
+                    // On small screens fill nearly the full height (within MUI's
+                    // default 32px dialog margins) instead of sizing to content.
+                    ...(isStacked && { height: 'calc(100% - 64px)' }),
                 },
             }}
             slotProps={{
@@ -95,67 +107,82 @@ export function ContinueWithAstaModal({
                 <CloseIcon />
             </CloseButton>
             <StyledDialogContent>
-                <SvgSlot aria-hidden="true">
-                    <svg
-                        role="img"
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="160"
-                        height="60"
-                        viewBox="0 0 153.44 57.41"
-                        fill="none"
-                        aria-labelledby="asta-logo">
-                        <title id="asta-logo"> Asta </title>
-                        <path
-                            fill="#0FCB8C"
-                            d="M14.15,24.7h-7.07v-6.84h5.7c.76,0,1.38-.63,1.38-1.4v-5.79h6.73v7.19c0,3.78-3.01,6.84-6.73,6.84ZM7.07,25.4H0v6.84h5.7c.76,0,1.38.63,1.38,1.4v5.79h6.73v-7.19c0-3.78-3.01-6.84-6.73-6.84ZM29.68,25.05c-.76,0-1.38-.63-1.38-1.4v-5.79h-6.73v7.19c0,3.78,3.01,6.84,6.73,6.84h7.07v-6.84h-5.7ZM14.49,39.43v7.19h6.73v-5.79c0-.77.62-1.4,1.38-1.4h5.7v-6.84h-7.07c-3.72,0-6.73,3.06-6.73,6.84Z"></path>
-                        <path
-                            fill="#0FCB8C"
-                            d="M138.49,47.28c-2.76,0-4.95-.7-6.56-2.1-1.58-1.4-2.37-3.33-2.37-5.81,0-2.22.63-4,1.88-5.32,1.29-1.36,3.39-2.29,6.29-2.8l6.72-1.13c1.33-.22,2.28-.56,2.85-1.02.61-.47.91-1.16.91-2.1,0-1.33-.45-2.33-1.34-3.01-.86-.72-2.38-1.08-4.57-1.08s-3.84.43-4.95,1.29c-1.08.86-1.68,2.15-1.83,3.87h-5.38c.04-2.9,1.09-5.18,3.17-6.83s5-2.47,8.76-2.47,6.36.75,8.23,2.26c1.9,1.51,2.85,3.53,2.85,6.08v13.33c0,1.97.09,4.01.27,6.13h-4.89c-.21-2.11-.32-4.14-.32-6.08-.61,1.94-1.72,3.55-3.33,4.84-1.61,1.29-3.75,1.94-6.4,1.94ZM139.62,43.14c2.72,0,4.84-.9,6.34-2.69,1.51-1.83,2.26-4.14,2.26-6.94v-1.61c-.65.47-1.34.84-2.1,1.13-.75.25-1.65.5-2.69.75l-3.71.86c-1.68.39-2.9.95-3.66,1.67-.75.68-1.13,1.63-1.13,2.85s.41,2.24,1.24,2.96c.86.68,2.01,1.02,3.44,1.02Z"></path>
-                        <path
-                            fill="#0FCB8C"
-                            d="M119.96,46.58c-2.15,0-3.82-.27-5-.81-1.15-.57-1.95-1.42-2.42-2.53-.47-1.15-.7-2.67-.7-4.57v-14.84h-5.11v-2.8l5.59-1.94,2.2-5.48h2.69v6.08h8.6v4.14h-8.6v18.44h8.07v4.3h-5.32Z"></path>
-                        <path
-                            fill="#0FCB8C"
-                            d="M85.57,37.6c.11,1.76.79,3.17,2.04,4.25,1.25,1.08,3.12,1.61,5.59,1.61,2.26,0,3.82-.34,4.68-1.02.86-.72,1.29-1.76,1.29-3.12,0-1.11-.34-1.97-1.02-2.58-.65-.65-1.67-1.08-3.06-1.29l-6.67-1.02c-2.33-.36-4.12-1.16-5.38-2.42-1.22-1.25-1.83-2.9-1.83-4.95,0-2.58.99-4.61,2.96-6.08,1.97-1.47,4.71-2.2,8.23-2.2s6.15.79,8.23,2.37c2.08,1.54,3.21,3.6,3.39,6.18h-5.38c-.14-1.33-.75-2.42-1.83-3.28-1.08-.86-2.6-1.29-4.57-1.29s-3.44.36-4.41,1.08c-.93.68-1.4,1.6-1.4,2.74,0,.9.27,1.63.81,2.2.57.57,1.54.97,2.9,1.18l5.81.86c3.15.47,5.36,1.4,6.61,2.8,1.25,1.36,1.88,3.17,1.88,5.43,0,2.8-.93,4.89-2.8,6.29-1.86,1.4-4.73,2.1-8.6,2.1-4.23,0-7.37-.9-9.41-2.69-2.04-1.83-3.06-4.21-3.06-7.15h5Z"></path>
-                        <path
-                            fill="#0FCB8C"
-                            d="M72.56,46.58l-3.17-8.5h-17.31l-3.17,8.5h-5.59l13.28-35.76h8.33l13.28,35.76h-5.65ZM53.74,33.63h13.98l-6.99-18.87-6.99,18.87Z"></path>
-                    </svg>
-                </SvgSlot>
-                <PromptFieldGroup>
-                    <PromptLabel htmlFor="continue-with-asta-prompt">{PROMPT_LABEL}</PromptLabel>
-                    <PromptField
-                        id="continue-with-asta-prompt"
-                        multiline
-                        minRows={4}
-                        maxRows={10}
-                        fullWidth
-                        value={prompt}
-                        onChange={(e) => setPrompt(e.target.value)}
-                        variant="outlined"
-                        placeholder="Ask a follow-up question, or leave blank and Asta will suggest questions."
-                    />
-                </PromptFieldGroup>
-                {error && (
-                    <Typography variant="body2" sx={{ color: 'error.main', mt: 0.5 }}>
-                        {error}
-                    </Typography>
+                {experiment && (
+                    <ContextColumn>
+                        <ContextTitle>Experiment ID: {experiment.idInRun}</ContextTitle>
+                        <Stack spacing={2}>
+                            <ExperimentContextSummary
+                                experiment={experiment}
+                                surprisalWidth={surprisalWidth}
+                            />
+                        </Stack>
+                    </ContextColumn>
                 )}
-                <Actions>
-                    <StartButton
-                        variant="outlined"
-                        endIcon={
-                            isLoading ? (
-                                <CircularProgress size={16} color="inherit" />
-                            ) : (
-                                <ArrowOutwardIcon />
-                            )
-                        }
-                        onClick={handleStart}
-                        disabled={!experiment || isLoading}>
-                        Start exploration
-                    </StartButton>
-                </Actions>
+                <MainColumn>
+                    <SvgSlot aria-hidden="true">
+                        <svg
+                            role="img"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="160"
+                            height="60"
+                            viewBox="0 0 153.44 57.41"
+                            fill="none"
+                            aria-labelledby="asta-logo">
+                            <title id="asta-logo"> Asta </title>
+                            <path
+                                fill="#0FCB8C"
+                                d="M14.15,24.7h-7.07v-6.84h5.7c.76,0,1.38-.63,1.38-1.4v-5.79h6.73v7.19c0,3.78-3.01,6.84-6.73,6.84ZM7.07,25.4H0v6.84h5.7c.76,0,1.38.63,1.38,1.4v5.79h6.73v-7.19c0-3.78-3.01-6.84-6.73-6.84ZM29.68,25.05c-.76,0-1.38-.63-1.38-1.4v-5.79h-6.73v7.19c0,3.78,3.01,6.84,6.73,6.84h7.07v-6.84h-5.7ZM14.49,39.43v7.19h6.73v-5.79c0-.77.62-1.4,1.38-1.4h5.7v-6.84h-7.07c-3.72,0-6.73,3.06-6.73,6.84Z"></path>
+                            <path
+                                fill="#0FCB8C"
+                                d="M138.49,47.28c-2.76,0-4.95-.7-6.56-2.1-1.58-1.4-2.37-3.33-2.37-5.81,0-2.22.63-4,1.88-5.32,1.29-1.36,3.39-2.29,6.29-2.8l6.72-1.13c1.33-.22,2.28-.56,2.85-1.02.61-.47.91-1.16.91-2.1,0-1.33-.45-2.33-1.34-3.01-.86-.72-2.38-1.08-4.57-1.08s-3.84.43-4.95,1.29c-1.08.86-1.68,2.15-1.83,3.87h-5.38c.04-2.9,1.09-5.18,3.17-6.83s5-2.47,8.76-2.47,6.36.75,8.23,2.26c1.9,1.51,2.85,3.53,2.85,6.08v13.33c0,1.97.09,4.01.27,6.13h-4.89c-.21-2.11-.32-4.14-.32-6.08-.61,1.94-1.72,3.55-3.33,4.84-1.61,1.29-3.75,1.94-6.4,1.94ZM139.62,43.14c2.72,0,4.84-.9,6.34-2.69,1.51-1.83,2.26-4.14,2.26-6.94v-1.61c-.65.47-1.34.84-2.1,1.13-.75.25-1.65.5-2.69.75l-3.71.86c-1.68.39-2.9.95-3.66,1.67-.75.68-1.13,1.63-1.13,2.85s.41,2.24,1.24,2.96c.86.68,2.01,1.02,3.44,1.02Z"></path>
+                            <path
+                                fill="#0FCB8C"
+                                d="M119.96,46.58c-2.15,0-3.82-.27-5-.81-1.15-.57-1.95-1.42-2.42-2.53-.47-1.15-.7-2.67-.7-4.57v-14.84h-5.11v-2.8l5.59-1.94,2.2-5.48h2.69v6.08h8.6v4.14h-8.6v18.44h8.07v4.3h-5.32Z"></path>
+                            <path
+                                fill="#0FCB8C"
+                                d="M85.57,37.6c.11,1.76.79,3.17,2.04,4.25,1.25,1.08,3.12,1.61,5.59,1.61,2.26,0,3.82-.34,4.68-1.02.86-.72,1.29-1.76,1.29-3.12,0-1.11-.34-1.97-1.02-2.58-.65-.65-1.67-1.08-3.06-1.29l-6.67-1.02c-2.33-.36-4.12-1.16-5.38-2.42-1.22-1.25-1.83-2.9-1.83-4.95,0-2.58.99-4.61,2.96-6.08,1.97-1.47,4.71-2.2,8.23-2.2s6.15.79,8.23,2.37c2.08,1.54,3.21,3.6,3.39,6.18h-5.38c-.14-1.33-.75-2.42-1.83-3.28-1.08-.86-2.6-1.29-4.57-1.29s-3.44.36-4.41,1.08c-.93.68-1.4,1.6-1.4,2.74,0,.9.27,1.63.81,2.2.57.57,1.54.97,2.9,1.18l5.81.86c3.15.47,5.36,1.4,6.61,2.8,1.25,1.36,1.88,3.17,1.88,5.43,0,2.8-.93,4.89-2.8,6.29-1.86,1.4-4.73,2.1-8.6,2.1-4.23,0-7.37-.9-9.41-2.69-2.04-1.83-3.06-4.21-3.06-7.15h5Z"></path>
+                            <path
+                                fill="#0FCB8C"
+                                d="M72.56,46.58l-3.17-8.5h-17.31l-3.17,8.5h-5.59l13.28-35.76h8.33l13.28,35.76h-5.65ZM53.74,33.63h13.98l-6.99-18.87-6.99,18.87Z"></path>
+                        </svg>
+                    </SvgSlot>
+                    <PromptFieldGroup>
+                        <PromptLabel htmlFor="continue-with-asta-prompt">
+                            {PROMPT_LABEL}
+                        </PromptLabel>
+                        <PromptField
+                            id="continue-with-asta-prompt"
+                            multiline
+                            minRows={4}
+                            maxRows={10}
+                            fullWidth
+                            value={prompt}
+                            onChange={(e) => setPrompt(e.target.value)}
+                            variant="outlined"
+                            placeholder="Ask a follow-up question, or leave blank and Asta will suggest questions."
+                        />
+                    </PromptFieldGroup>
+                    {error && (
+                        <Typography variant="body2" sx={{ color: 'error.main', mt: 0.5 }}>
+                            {error}
+                        </Typography>
+                    )}
+                    <Actions>
+                        <StartButton
+                            variant="outlined"
+                            endIcon={
+                                isLoading ? (
+                                    <CircularProgress size={16} color="inherit" />
+                                ) : (
+                                    <ArrowOutwardIcon />
+                                )
+                            }
+                            onClick={handleStart}
+                            disabled={!experiment || isLoading}>
+                            Start exploration
+                        </StartButton>
+                    </Actions>
+                </MainColumn>
             </StyledDialogContent>
         </Dialog>
     );
@@ -174,9 +201,58 @@ const StyledDialogContent = styled(DialogContent)`
     background-color: ${({ theme }) => theme.color['extra-dark-teal-100'].hex};
     color: ${({ theme }) => theme.color['cream-100'].hex};
     display: flex;
+    flex-direction: row;
+    gap: 0;
+    /* No padding here so the divider between columns spans the full height/width. */
+    padding: 0 !important;
+    overflow: hidden;
+
+    @media (max-width: 700px) {
+        flex-direction: column;
+        height: 100%;
+    }
+`;
+
+const ContextColumn = styled(Box)`
+    flex: 2 1 0;
+    min-width: 0;
+    max-height: 60vh;
+    overflow-y: auto;
+    padding: ${({ theme }) => theme.spacing(5, 4, 4)};
+    border-right: 1px solid ${({ theme }) => theme.color['cream-10'].rgba.toString()};
+
+    @media (max-width: 700px) {
+        flex: 1 1 auto;
+        max-height: none;
+        border-right: none;
+        border-bottom: 1px solid ${({ theme }) => theme.color['cream-10'].rgba.toString()};
+        /* Inset shadow at the bottom edge hints there's more to scroll to. */
+        box-shadow: inset 0 -16px 14px -14px rgba(0, 0, 0, 0.7);
+    }
+`;
+
+const ContextTitle = styled('h2')`
+    color: ${({ theme }) => theme.color['cream-100'].hex};
+    font-family: 'PP Telegraf', Manrope, sans-serif;
+    font-weight: 700;
+    font-size: 20px;
+    line-height: 24px;
+    margin: 0 0 ${({ theme }) => theme.spacing(2)};
+`;
+
+const MainColumn = styled(Box)`
+    flex: 1 1 0;
+    min-width: 0;
+    display: flex;
     flex-direction: column;
     gap: 8px;
-    padding: ${({ theme }) => theme.spacing(5, 4, 4)} !important;
+    padding: ${({ theme }) => theme.spacing(5, 4, 4)};
+    /* Slightly darker than the context column to distinguish the two panels. */
+    background-color: rgba(0, 0, 0, 0.2);
+
+    @media (max-width: 700px) {
+        flex: 0 0 auto;
+    }
 `;
 
 const SvgSlot = styled(Box)`

--- a/ui/src/app/runs/components/ExperimentContextSummary.tsx
+++ b/ui/src/app/runs/components/ExperimentContextSummary.tsx
@@ -1,0 +1,147 @@
+import { Box, styled, Typography } from '@mui/material';
+import { Markdown } from '@allenai/varnish2/components';
+
+import { Experiment, ExperimentStatus } from '@/types/Run';
+import { getSurprisalDirection, escapeMarkdown } from '@/runs/utils/ExperimentUtils';
+import { BeliefDistributionPlot } from '@/runs/components/BeliefDistributionPlot';
+
+type ExperimentContextSummaryProps = {
+    experiment: Experiment;
+    surprisalWidth?: number | null;
+};
+
+/**
+ * Renders the Belief Shift, Hypothesis, and Analysis sections for an experiment.
+ * Shared between the experiment detail panel and the Continue with Asta modal so the
+ * two stay visually in sync. Parent is expected to supply vertical spacing between the
+ * rendered <Box> sections (e.g. a Stack with spacing).
+ */
+export function ExperimentContextSummary({
+    experiment,
+    surprisalWidth,
+}: ExperimentContextSummaryProps) {
+    // Mirror the table's threshold logic so the panel and the Surprisal column stay in sync.
+    const isSurprising =
+        experiment.status !== ExperimentStatus.SUCCEEDED
+            ? false
+            : surprisalWidth != null
+              ? Math.abs(experiment.surprise ?? 0) >= surprisalWidth
+              : experiment.isSurprising;
+
+    return (
+        <>
+            {(experiment.surprise !== null ||
+                experiment.priorBelief ||
+                experiment.posteriorBelief) && (
+                <Box>
+                    <SectionHeader>
+                        Belief Shift
+                        {experiment.surprise !== null &&
+                            (isSurprising ? (
+                                <OrangeText>
+                                    : {getSurprisalDirection(experiment.surprise)} (
+                                    {experiment.surprise.toFixed(3)})
+                                </OrangeText>
+                            ) : (
+                                <CreamText>
+                                    : {getSurprisalDirection(experiment.surprise)} (
+                                    {experiment.surprise.toFixed(3)})
+                                </CreamText>
+                            ))}
+                    </SectionHeader>
+                    {(experiment.priorBelief || experiment.posteriorBelief) && (
+                        <BeliefDistributionPlot
+                            prior={experiment.priorBelief}
+                            posterior={experiment.posteriorBelief}
+                            isSurprising={isSurprising}
+                        />
+                    )}
+                </Box>
+            )}
+
+            {experiment.hypothesis && (
+                <Box>
+                    <SectionHeader>Hypothesis</SectionHeader>
+                    <StyledMarkdown>{escapeMarkdown(experiment.hypothesis)}</StyledMarkdown>
+                </Box>
+            )}
+
+            {experiment.analysis && (
+                <Box>
+                    <SectionHeader>Analysis</SectionHeader>
+                    <StyledMarkdown>{escapeMarkdown(experiment.analysis)}</StyledMarkdown>
+                </Box>
+            )}
+        </>
+    );
+}
+
+export const SectionHeader = styled(Typography)`
+    color: ${({ theme }) => theme.color['green-40'].rgba.toString()};
+    font-weight: 700;
+`;
+
+export const OrangeText = styled('strong')`
+    color: ${({ theme }) => theme.color['warning-orange-100'].hex};
+`;
+
+export const CreamText = styled('strong')`
+    color: ${({ theme }) => theme.color['cream-100'].hex};
+`;
+
+export const StyledMarkdown = styled(Markdown)`
+    margin-top: ${({ theme }) => theme.spacing(0.5)};
+
+    &,
+    & * {
+        font-size: 0.875rem !important;
+        margin: 0;
+    }
+
+    & ol,
+    & ul {
+        padding-left: 1.5em;
+        margin: 0.25em 0;
+    }
+
+    & li {
+        margin: 0.125em 0;
+    }
+
+    & p {
+        margin: 0.25em 0;
+    }
+
+    & p:first-of-type {
+        margin-top: 0;
+    }
+
+    /*
+     * Varnish2's Markdown maps every <code> (inline or block) to a block-level
+     * <pre>, which shows single-backtick inline code as a full-width dark block.
+     * Inline code comes out as <p><pre>...</pre></p>; block code as
+     * <span><pre>...</pre></span>. Reset <pre> to inline appearance and keep
+     * block styling only when it's wrapped by varnish2's <span>.
+     */
+    & pre {
+        display: inline;
+        padding: 1px 6px;
+        margin: 0 2px;
+        max-height: none;
+        max-width: fit-content;
+        overflow: visible;
+        font-size: 0.85em;
+        line-height: inherit;
+        vertical-align: baseline;
+    }
+
+    & span > pre {
+        display: block;
+        padding: ${({ theme }) => theme.spacing(2)};
+        margin: ${({ theme }) => theme.spacing(1)} 0;
+        max-width: 100%;
+        overflow: auto;
+        font-size: 0.8125rem;
+        line-height: 1.4;
+    }
+`;

--- a/ui/src/app/runs/components/ExperimentDetails.tsx
+++ b/ui/src/app/runs/components/ExperimentDetails.tsx
@@ -1,14 +1,17 @@
 import { memo, ReactNode, useEffect, useRef, useState } from 'react';
 import { styled, Typography, Box, Stack, Button } from '@mui/material';
-import { Markdown } from '@allenai/varnish2/components';
 
 import { Experiment, ExperimentStatus } from '@/types/Run';
 import { CodeBlock } from '@/components/CodeBlock';
-import { getSurprisalDirection, escapeMarkdown } from '@/runs/utils/ExperimentUtils';
+import { escapeMarkdown } from '@/runs/utils/ExperimentUtils';
 import { useRunExperiments } from '@/contexts/RunExperimentsContext';
 import { StatusChip } from '@/runs/components/StatusChip';
 import { RichOutputsSection } from '@/runs/components/RichOutputsSection';
-import { BeliefDistributionPlot } from '@/runs/components/BeliefDistributionPlot';
+import {
+    ExperimentContextSummary,
+    SectionHeader,
+    StyledMarkdown,
+} from '@/runs/components/ExperimentContextSummary';
 import { ExperimentBookmarkControl } from './ExperimentBookmarkControl';
 import { ContinueWithAstaModal } from './ContinueWithAstaModal';
 
@@ -60,14 +63,6 @@ export const ExperimentDetails = memo(function ExperimentDetails({
         };
     }, []);
 
-    // Mirror the table's threshold logic so the panel and the Surprisal column stay in sync.
-    const isSurprising =
-        experiment.status !== ExperimentStatus.SUCCEEDED
-            ? false
-            : surprisalWidth != null
-              ? Math.abs(experiment.surprise ?? 0) >= surprisalWidth
-              : experiment.isSurprising;
-
     return (
         <DetailsWrapper ref={wrapperRef} spacing={0}>
             <TitleWrapper>
@@ -91,48 +86,7 @@ export const ExperimentDetails = memo(function ExperimentDetails({
                     </Box>
                 )}
 
-                {(experiment.surprise !== null ||
-                    experiment.priorBelief ||
-                    experiment.posteriorBelief) && (
-                    <Box>
-                        <SectionHeader>
-                            Belief Shift
-                            {experiment.surprise !== null &&
-                                (isSurprising ? (
-                                    <OrangeText>
-                                        : {getSurprisalDirection(experiment.surprise)} (
-                                        {experiment.surprise.toFixed(3)})
-                                    </OrangeText>
-                                ) : (
-                                    <CreamText>
-                                        : {getSurprisalDirection(experiment.surprise)} (
-                                        {experiment.surprise.toFixed(3)})
-                                    </CreamText>
-                                ))}
-                        </SectionHeader>
-                        {(experiment.priorBelief || experiment.posteriorBelief) && (
-                            <BeliefDistributionPlot
-                                prior={experiment.priorBelief}
-                                posterior={experiment.posteriorBelief}
-                                isSurprising={isSurprising}
-                            />
-                        )}
-                    </Box>
-                )}
-
-                {experiment.hypothesis && (
-                    <Box>
-                        <SectionHeader>Hypothesis</SectionHeader>
-                        <StyledMarkdown>{escapeMarkdown(experiment.hypothesis)}</StyledMarkdown>
-                    </Box>
-                )}
-
-                {experiment.analysis && (
-                    <Box>
-                        <SectionHeader>Analysis</SectionHeader>
-                        <StyledMarkdown>{escapeMarkdown(experiment.analysis)}</StyledMarkdown>
-                    </Box>
-                )}
+                <ExperimentContextSummary experiment={experiment} surprisalWidth={surprisalWidth} />
 
                 {experiment.experimentPlan && (
                     <>
@@ -215,6 +169,7 @@ export const ExperimentDetails = memo(function ExperimentDetails({
                             onClose={() => setIsContinueModalOpen(false)}
                             runId={runId}
                             experiment={experiment}
+                            surprisalWidth={surprisalWidth}
                         />
                     </>
                 ))}
@@ -265,19 +220,6 @@ const Bookmark = styled('div')`
     .MuiIconButton-root {
         padding: 0px 8px 1px 8px;
     }
-`;
-
-const SectionHeader = styled(Typography)`
-    color: ${({ theme }) => theme.color['green-40'].rgba.toString()};
-    font-weight: 700;
-`;
-
-const OrangeText = styled('strong')`
-    color: ${({ theme }) => theme.color['warning-orange-100'].hex};
-`;
-
-const CreamText = styled('strong')`
-    color: ${({ theme }) => theme.color['cream-100'].hex};
 `;
 
 const BottomBar = styled('div')<{ $visible: boolean }>`
@@ -332,62 +274,5 @@ const ContinueExploringButton = styled(Button)`
             color: ${({ theme }) => theme.color['green-100'].hex};
             border: 1px solid ${({ theme }) => theme.color['green-100'].hex};
         }
-    }
-`;
-
-const StyledMarkdown = styled(Markdown)`
-    margin-top: ${({ theme }) => theme.spacing(0.5)};
-
-    &,
-    & * {
-        font-size: 0.875rem !important;
-        margin: 0;
-    }
-
-    & ol,
-    & ul {
-        padding-left: 1.5em;
-        margin: 0.25em 0;
-    }
-
-    & li {
-        margin: 0.125em 0;
-    }
-
-    & p {
-        margin: 0.25em 0;
-    }
-
-    & p:first-of-type {
-        margin-top: 0;
-    }
-
-    /*
-     * Varnish2's Markdown maps every <code> (inline or block) to a block-level
-     * <pre>, which shows single-backtick inline code as a full-width dark block.
-     * Inline code comes out as <p><pre>...</pre></p>; block code as
-     * <span><pre>...</pre></span>. Reset <pre> to inline appearance and keep
-     * block styling only when it's wrapped by varnish2's <span>.
-     */
-    & pre {
-        display: inline;
-        padding: 1px 6px;
-        margin: 0 2px;
-        max-height: none;
-        max-width: fit-content;
-        overflow: visible;
-        font-size: 0.85em;
-        line-height: inherit;
-        vertical-align: baseline;
-    }
-
-    & span > pre {
-        display: block;
-        padding: ${({ theme }) => theme.spacing(2)};
-        margin: ${({ theme }) => theme.spacing(1)} 0;
-        max-width: 100%;
-        overflow: auto;
-        font-size: 0.8125rem;
-        line-height: 1.4;
     }
 `;

--- a/ui/src/app/runs/components/ExperimentsTable.tsx
+++ b/ui/src/app/runs/components/ExperimentsTable.tsx
@@ -494,6 +494,7 @@ export function ExperimentsTable({
                     onClose={() => setContinueExperiment(null)}
                     runId={runid ?? ''}
                     experiment={continueExperiment}
+                    surprisalWidth={surprisalWidth}
                 />
             )}
         </>


### PR DESCRIPTION
<img width="1780" height="1152" alt="image" src="https://github.com/user-attachments/assets/bfa08371-f9be-485c-9724-2b03fc21e301" />

- Add ExperimentContextSummary component (Belief Shift, Hypothesis, Analysis), shared between the detail panel and modal so they stay in sync
- Render experiment context in a left panel of the modal with the experiment ID as a title; thread surprisalWidth through for matching surprisal coloring
- Two-column layout (2:1 context:prompt) with a full-bleed divider and a darker Explore panel for clearer separation
- On small screens, stack the panels, fill near-full height within dialog margins, and show a scroll-affordance shadow on the context column

This handles:
https://github.com/allenai/nora-issues/issues/2938
https://github.com/allenai/nora-issues/issues/2924