### PR TITLE
Fix table loading strangeness

### DIFF
--- a/ui/src/app/contexts/Auth0Context.tsx
+++ b/ui/src/app/contexts/Auth0Context.tsx
@@ -21,6 +21,7 @@ export interface Auth0ContextType {
     logout: () => void;
     getAccessToken: () => Promise<string>;
     hasRequiredPermission: boolean;
+    canExploreWithAsta: boolean;
     authError: string | null;
 }
 
@@ -35,6 +36,7 @@ export function Auth0Provider({ children }: Auth0ProviderProps) {
     const [isLoading, setIsLoading] = useState(true);
     const [user, setUser] = useState<User | undefined>(undefined);
     const [hasRequiredPermission, setHasRequiredPermission] = useState(false);
+    const [canExploreWithAsta, setCanExploreWithAsta] = useState(false);
     const [authError, setAuthError] = useState<string | null>(null);
 
     useEffect(() => {
@@ -66,36 +68,35 @@ export function Auth0Provider({ children }: Auth0ProviderProps) {
                     const userProfile = await auth0Client.getUser();
                     setUser(userProfile);
 
-                    // Check for required permission if specified
-                    if (auth0Config.requiredPermission) {
-                        try {
-                            const token = await auth0Client.getTokenSilently();
+                    // Decode the access token to check permissions.
+                    // Note: This is a simple decode, not validation (validation happens on backend)
+                    try {
+                        const token = await auth0Client.getTokenSilently();
+                        const tokenParts = token.split('.');
+                        const payload = JSON.parse(atob(tokenParts[1]));
+                        const permissions: string[] = Array.isArray(payload.permissions)
+                            ? payload.permissions
+                            : [];
 
-                            // Decode the access token to get permissions
-                            // Note: This is a simple decode, not validation (validation happens on backend)
-                            const tokenParts = token.split('.');
-                            const payload = JSON.parse(atob(tokenParts[1]));
-
-                            // Permissions are typically in the "permissions" claim
-                            const permissions = payload.permissions || [];
-
-                            const hasPermission =
-                                Array.isArray(permissions) &&
-                                permissions.includes(auth0Config.requiredPermission);
+                        if (auth0Config.requiredPermission) {
+                            const hasPermission = permissions.includes(
+                                auth0Config.requiredPermission
+                            );
                             setHasRequiredPermission(hasPermission);
-
                             if (!hasPermission) {
                                 setAuthError(
                                     `Access denied. Required permission: ${auth0Config.requiredPermission}`
                                 );
                                 // Don't auto-logout - let the dialog handle user action
                             }
-                        } catch (error) {
-                            console.error('Error checking permissions:', error);
-                            setAuthError('Failed to verify user permissions');
+                        } else {
+                            setHasRequiredPermission(true);
                         }
-                    } else {
-                        setHasRequiredPermission(true);
+
+                        setCanExploreWithAsta(permissions.includes('enroll:asta_integration'));
+                    } catch (error) {
+                        console.error('Error checking permissions:', error);
+                        setAuthError('Failed to verify user permissions');
                     }
                 }
 
@@ -148,6 +149,7 @@ export function Auth0Provider({ children }: Auth0ProviderProps) {
             logout,
             getAccessToken,
             hasRequiredPermission,
+            canExploreWithAsta,
             authError,
         }),
         [
@@ -158,6 +160,7 @@ export function Auth0Provider({ children }: Auth0ProviderProps) {
             logout,
             getAccessToken,
             hasRequiredPermission,
+            canExploreWithAsta,
             authError,
         ]
     );

--- a/ui/src/app/runs/components/ExperimentDetails.tsx
+++ b/ui/src/app/runs/components/ExperimentDetails.tsx
@@ -4,6 +4,7 @@ import { styled, Typography, Box, Stack, Button } from '@mui/material';
 import { Experiment, ExperimentStatus } from '@/types/Run';
 import { CodeBlock } from '@/components/CodeBlock';
 import { escapeMarkdown } from '@/runs/utils/ExperimentUtils';
+import { useAuth0 } from '@/contexts/Auth0Context';
 import { useRunExperiments } from '@/contexts/RunExperimentsContext';
 import { StatusChip } from '@/runs/components/StatusChip';
 import { RichOutputsSection } from '@/runs/components/RichOutputsSection';
@@ -21,7 +22,6 @@ type ExperimentDetailsProps = {
     actions?: ReactNode;
     surprisalWidth?: number | null;
     datasetExpired?: boolean;
-    canExploreWithAsta?: boolean;
 };
 
 export const ExperimentDetails = memo(function ExperimentDetails({
@@ -30,8 +30,8 @@ export const ExperimentDetails = memo(function ExperimentDetails({
     actions,
     surprisalWidth,
     datasetExpired,
-    canExploreWithAsta = false,
 }: ExperimentDetailsProps) {
+    const { canExploreWithAsta } = useAuth0();
     const { isLoadingSelectedExperiment, selectedExperimentError } = useRunExperiments();
     const richOutputs = experiment.richOutputs ?? [];
     const hasRichOutputs = richOutputs.length > 0;

--- a/ui/src/app/runs/components/ExperimentsTable.tsx
+++ b/ui/src/app/runs/components/ExperimentsTable.tsx
@@ -9,6 +9,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { RunStats, ExperimentStatus, Experiment } from '@/types/Run';
+import { useAuth0 } from '@/contexts/Auth0Context';
 import { useRunExperiments } from '@/contexts/RunExperimentsContext';
 import { useExperimentBookmarks } from '@/contexts/ExperimentBookmarksContext';
 import { getPriorAndPosteriorLabel, getSurprisalDirection } from '@/runs/utils/ExperimentUtils';
@@ -25,15 +26,14 @@ interface ExperimentsTableProps {
     runStats?: RunStats | null;
     surprisalWidth?: number | null;
     datasetExpired?: boolean;
-    canExploreWithAsta?: boolean;
 }
 
 export function ExperimentsTable({
     runStats,
     surprisalWidth,
     datasetExpired,
-    canExploreWithAsta = false,
 }: ExperimentsTableProps) {
+    const { canExploreWithAsta } = useAuth0();
     const {
         experiments,
         lastError,

--- a/ui/src/app/runs/components/RunView.tsx
+++ b/ui/src/app/runs/components/RunView.tsx
@@ -285,7 +285,6 @@ function RunViewContent({
     const datasetExpired = isDatasetExpired(run.datasetExpiresAt);
     const datasetExpiryLabel = getDatasetExpiryLabel(run.datasetExpiresAt);
     const canFork = !datasetExpired && !isForking;
-    const canExploreWithAsta = run.canExploreWithAsta ?? false;
 
     const handleFork = useCallback(async () => {
         setIsForking(true);
@@ -767,7 +766,6 @@ function RunViewContent({
                             runStats={run.stats}
                             surprisalWidth={run.metadata?.surprisalWidth}
                             datasetExpired={datasetExpired}
-                            canExploreWithAsta={canExploreWithAsta}
                         />
                     </RunContent>
                     {isDragEnabled && (
@@ -803,7 +801,6 @@ function RunViewContent({
                                 runId={run.id}
                                 surprisalWidth={run.metadata?.surprisalWidth}
                                 datasetExpired={datasetExpired}
-                                canExploreWithAsta={canExploreWithAsta}
                                 actions={
                                     <>
                                         <Tooltip title="Share experiment" placement="bottom">


### PR DESCRIPTION
**Problem**: I noticed 1 more UI bug that i think would be nice to fix before the preview launch - when you click a thread there's sometimes a little bit of lag between the thread loading and the "exploration" column in the table appearing.

I realized this was due to the UI checking user permissions after the initial cache load for an existing thread. 

Made changes so now the permission is checked once at login by decoding the JWT in Auth0Context (same approach used by the metrics admin gate), making it available immediately without any extra API calls or prop drilling.

Tested and validated that this got rid of the lag!