### PR TITLE
e2e: make global-setup health-check failures diagnosable

### DIFF
--- a/ui/e2e/global-setup.ts
+++ b/ui/e2e/global-setup.ts
@@ -1,7 +1,30 @@
 import { FullConfig } from '@playwright/test';
 
 const RETRY_INTERVAL_MS = 5000;
+const REQUEST_TIMEOUT_MS = 10000;
 const TIMEOUT_MS = 120000;
+
+/**
+ * Render an error from the health-check fetch in a way that is actually
+ * diagnosable in CI. A bare `${err}` on a failed `fetch()` stringifies to just
+ * "TypeError: fetch failed" and drops `err.cause`, which is where undici stashes
+ * the real reason (DNS lookup failure, ECONNREFUSED, ETIMEDOUT, TLS error, …).
+ * Without the cause we cannot tell a down/unreachable endpoint apart from a real
+ * app-level error, so surface it explicitly.
+ */
+function describeError(err: unknown): string {
+    if (!(err instanceof Error)) return String(err);
+
+    const parts = [`${err.name}: ${err.message}`];
+    const cause = (err as { cause?: unknown }).cause;
+    if (cause instanceof Error) {
+        const code = (cause as { code?: string }).code;
+        parts.push(`cause: ${cause.name}: ${cause.message}${code ? ` (${code})` : ''}`);
+    } else if (cause !== undefined) {
+        parts.push(`cause: ${String(cause)}`);
+    }
+    return parts.join(' | ');
+}
 
 export default async function globalSetup(config: FullConfig) {
     const baseURL = config.projects[0].use.baseURL ?? 'http://localhost:8080/';
@@ -9,10 +32,16 @@ export default async function globalSetup(config: FullConfig) {
 
     const deadline = Date.now() + TIMEOUT_MS;
     let lastError: unknown;
+    let attempts = 0;
 
     while (Date.now() < deadline) {
+        attempts++;
         try {
-            const res = await fetch(HEALTH_URL);
+            // Bound each attempt so a single stalled handshake can't hang the
+            // whole setup, and so a wedged connection eventually retries.
+            const res = await fetch(HEALTH_URL, {
+                signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            });
             if (res.ok) return;
             lastError = new Error(`Health check returned HTTP ${res.status}`);
         } catch (err) {
@@ -22,8 +51,11 @@ export default async function globalSetup(config: FullConfig) {
     }
 
     throw new Error(
-        `Server did not become ready within ${TIMEOUT_MS / 1000}s. Start it with "yarn dev -p 8080" before running tests.\n` +
+        `Server health check did not succeed within ${TIMEOUT_MS / 1000}s (${attempts} attempts).\n` +
             `Health check URL: ${HEALTH_URL}\n` +
-            `Last error: ${lastError}`
+            `Last error: ${describeError(lastError)}\n` +
+            `A connection-level failure (DNS/ECONNREFUSED/ETIMEDOUT/TLS) means the runner ` +
+            `could not reach E2E_BASE_URL, not that your change is broken. For a local run, ` +
+            `start the app with "yarn dev -p 8080" first.`
     );
 }


### PR DESCRIPTION
## Why

The Playwright `globalSetup` ([`ui/e2e/global-setup.ts`](https://github.com/allenai/asta-autodiscovery/blob/main/ui/e2e/global-setup.ts)) polls `E2E_BASE_URL` + `/api/runs/health` every 5s for 120s and aborts the whole suite if it never gets a healthy response.

On a connection-level failure it logged `` `${lastError}` ``, which stringifies a failed `fetch()` to just `TypeError: fetch failed` and **drops `err.cause`** — the field undici uses to record the real reason (DNS lookup failure, `ECONNREFUSED`, `ETIMEDOUT`, TLS error).

This bit us repeatedly: the e2e job on `asta-autodiscovery-private` failed three times in a row against the shared `*-dev` deployment with the identical opaque `fetch failed` for the full 120s, while the endpoint was healthy and fast from outside the runner. Because the cause was swallowed, there was no way to tell an *unreachable/blocked endpoint* apart from a *real app-level error* — so every triage was a guess.

## What

- **Surface `err.cause`** (and its `code`) in the thrown message, so the next failure says *why* the connection failed instead of just `fetch failed`.
- **Bound each attempt** with a 10s `AbortSignal.timeout`, so a single stalled handshake can't hang the setup and a wedged connection actually retries within the 120s window.
- Report the **attempt count** and clarify that a connection-level failure means the runner couldn't reach `E2E_BASE_URL`, not that the change under test is broken.

This is purely diagnostic/robustness hardening — it does **not** change the pass/fail policy (a never-reachable endpoint still fails the job).

## Deliberately not included (needs a decision)

The deeper issue is that this suite is **non-hermetic**: a green check currently means "the dev box happened to be reachable from this runner," not "the code is good." Two follow-ups worth discussing:

1. Treat a connection-level failure (vs. an app-level unhealthy HTTP response) as a **neutral skip** rather than a red PR check — unblocks PRs when the shared dev env is unreachable, but risks masking a genuinely-down dev deployment. Left out on purpose because that's a policy call.
2. Longer term, make the suite hermetic (spin the app up in CI against mocks) so the check stops depending on a shared external deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)