### PR TITLE
add analytics

### DIFF
--- a/ui/src/app/analytics/runDetails.ts
+++ b/ui/src/app/analytics/runDetails.ts
@@ -28,3 +28,17 @@ export const mkDownloadCsvMenuItemAttrs = (props: { runId: string }) =>
 // Download JSON menu item click
 export const mkDownloadJsonMenuItemAttrs = (props: { runId: string }) =>
     mkTrackAttrs(`${RUN_DETAILS}__download_json`, props);
+
+// Explore with Asta table link click (opens modal from experiments table)
+export const mkExploreWithAstaTableLinkAttrs = (props: { runId: string; experimentId: string }) =>
+    mkTrackAttrs(`${RUN_DETAILS}__explore_with_asta_table_link`, props);
+
+// Continue exploring with Asta button click (opens modal from experiment detail panel)
+export const mkContinueExploringWithAstaBtnAttrs = (props: {
+    runId: string;
+    experimentId: string;
+}) => mkTrackAttrs(`${RUN_DETAILS}__continue_exploring_with_asta_btn`, props);
+
+// Start Asta exploration event name (fired when user confirms and launches Asta)
+export const startAstaExplorationEventName =
+    `${RUN_DETAILS}__start_asta_exploration` as const;

--- a/ui/src/app/analytics/runDetails.ts
+++ b/ui/src/app/analytics/runDetails.ts
@@ -40,5 +40,4 @@ export const mkContinueExploringWithAstaBtnAttrs = (props: {
 }) => mkTrackAttrs(`${RUN_DETAILS}__continue_exploring_with_asta_btn`, props);
 
 // Start Asta exploration event name (fired when user confirms and launches Asta)
-export const startAstaExplorationEventName =
-    `${RUN_DETAILS}__start_asta_exploration` as const;
+export const startAstaExplorationEventName = `${RUN_DETAILS}__start_asta_exploration` as const;

--- a/ui/src/app/runs/components/ContinueWithAstaModal.tsx
+++ b/ui/src/app/runs/components/ContinueWithAstaModal.tsx
@@ -20,6 +20,8 @@ import { useEffect, useState } from 'react';
 import { getRunsApi } from '@/api/RunsApi';
 import { Experiment } from '@/types/Run';
 import { ExperimentContextSummary } from '@/runs/components/ExperimentContextSummary';
+import { startAstaExplorationEventName } from '@/analytics/runDetails';
+import { track } from '@/analytics/track';
 
 interface ContinueWithAstaModalProps {
     open: boolean;
@@ -61,7 +63,12 @@ export function ContinueWithAstaModal({
                 experimentId: experiment.experimentId,
                 query: prompt,
             });
-            window.open(result.data.asta_url, '_blank', 'noopener,noreferrer');
+            track(startAstaExplorationEventName, {
+                runId,
+                experimentId: experiment.experimentId,
+                hasCustomPrompt: prompt.trim().length > 0,
+            });
+window.open(result.data.asta_url, '_blank', 'noopener,noreferrer');
             onClose();
         } catch {
             setError('Failed to start Asta session. Please try again.');

--- a/ui/src/app/runs/components/ContinueWithAstaModal.tsx
+++ b/ui/src/app/runs/components/ContinueWithAstaModal.tsx
@@ -68,7 +68,7 @@ export function ContinueWithAstaModal({
                 experimentId: experiment.experimentId,
                 hasCustomPrompt: prompt.trim().length > 0,
             });
-window.open(result.data.asta_url, '_blank', 'noopener,noreferrer');
+            window.open(result.data.asta_url, '_blank', 'noopener,noreferrer');
             onClose();
         } catch {
             setError('Failed to start Asta session. Please try again.');

--- a/ui/src/app/runs/components/ExperimentDetails.tsx
+++ b/ui/src/app/runs/components/ExperimentDetails.tsx
@@ -6,6 +6,7 @@ import { CodeBlock } from '@/components/CodeBlock';
 import { escapeMarkdown } from '@/runs/utils/ExperimentUtils';
 import { useAuth0 } from '@/contexts/Auth0Context';
 import { useRunExperiments } from '@/contexts/RunExperimentsContext';
+import { mkContinueExploringWithAstaBtnAttrs } from '@/analytics/runDetails';
 import { StatusChip } from '@/runs/components/StatusChip';
 import { RichOutputsSection } from '@/runs/components/RichOutputsSection';
 import {
@@ -160,6 +161,10 @@ export const ExperimentDetails = memo(function ExperimentDetails({
                         <BottomBar $visible={hasScrolled}>
                             <ContinueExploringButton
                                 variant="outlined"
+                                {...mkContinueExploringWithAstaBtnAttrs({
+                                    runId,
+                                    experimentId: experiment.experimentId,
+                                })}
                                 onClick={() => setIsContinueModalOpen(true)}>
                                 Continue exploring with Asta
                             </ContinueExploringButton>

--- a/ui/src/app/runs/components/ExperimentsTable.tsx
+++ b/ui/src/app/runs/components/ExperimentsTable.tsx
@@ -225,7 +225,7 @@ export function ExperimentsTable({
                             onClick={(e) => {
                                 e.stopPropagation();
                                 e.preventDefault();
-setExploredExperimentIds((prev) =>
+                                setExploredExperimentIds((prev) =>
                                     new Set(prev).add(params.row.id as string)
                                 );
                                 setContinueExperiment(params.row.experiment);

--- a/ui/src/app/runs/components/ExperimentsTable.tsx
+++ b/ui/src/app/runs/components/ExperimentsTable.tsx
@@ -13,7 +13,11 @@ import { useAuth0 } from '@/contexts/Auth0Context';
 import { useRunExperiments } from '@/contexts/RunExperimentsContext';
 import { useExperimentBookmarks } from '@/contexts/ExperimentBookmarksContext';
 import { getPriorAndPosteriorLabel, getSurprisalDirection } from '@/runs/utils/ExperimentUtils';
-import { mkExperimentRowAttrs, sortColumnEventName } from '@/analytics/runDetails';
+import {
+    mkExperimentRowAttrs,
+    mkExploreWithAstaTableLinkAttrs,
+    sortColumnEventName,
+} from '@/analytics/runDetails';
 import { track } from '@/analytics/track';
 import { useURLSearchParams } from '@/contexts/URLSearchParamsContext';
 import { ExperimentBookmarkControl } from './ExperimentBookmarkControl';
@@ -214,10 +218,14 @@ export function ExperimentsTable({
                         <ExplorationLink
                             href="#"
                             className={isExplored ? 'explored' : 'not-explored'}
+                            {...mkExploreWithAstaTableLinkAttrs({
+                                runId: runid ?? '',
+                                experimentId: params.row.experiment?.experimentId,
+                            })}
                             onClick={(e) => {
                                 e.stopPropagation();
                                 e.preventDefault();
-                                setExploredExperimentIds((prev) =>
+setExploredExperimentIds((prev) =>
                                     new Set(prev).add(params.row.id as string)
                                 );
                                 setContinueExperiment(params.row.experiment);


### PR DESCRIPTION
Add analytics tracking for Asta exploration buttons

   Tracks three events via Heap:
   - Table "Explore with Asta" link click (data-track-name) `explore_with_asta_table_link `
   - Detail panel "Continue exploring with Asta" button click (data-track-name) `continue_exploring_with_asta_btn`
   - The third fires imperatively on success so you can distinguish intent (clicking the button) from conversion
  (Asta actually launching).  `start_asta_exploration`
