### PR TITLE
Require SMTP_SERVER and SENDER_EMAIL env vars for the email job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,11 @@ AUTH0_MGMT_DOMAIN=
 AUTH0_MGMT_CLIENT_ID=
 AUTH0_MGMT_CLIENT_SECRET=
 
+# Email job: mail server and from-address (required to send; port defaults to 25)
+SMTP_SERVER=
+SENDER_EMAIL=
+# SMTP_PORT=25
+
 # Optional: Required Auth0 permission for authenticated users to access the API.
 # If not set or empty, any authenticated user can access the system.
 # Example: AUTH0_REQUIRED_PERMISSION=enroll:autodiscovery_v0

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/__init__.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/__init__.py
@@ -90,9 +90,8 @@ from .auth0 import (
 
 # Email sending
 from .email import (
+    EmailError,
     send_email,
-    DEFAULT_SENDER_EMAIL,
-    DEFAULT_SMTP_SERVER,
 )
 
 __version__ = "0.2.2"
@@ -154,7 +153,6 @@ __all__ = [
     # Auth0 functions
     "get_user",
     # Email functions
+    "EmailError",
     "send_email",
-    "DEFAULT_SENDER_EMAIL",
-    "DEFAULT_SMTP_SERVER",
 ]

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/email.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/email.py
@@ -1,30 +1,47 @@
 """Email sending utilities.
 
 This module provides functions for sending emails via SMTP.
+
+Required environment variables:
+    SMTP_SERVER: Mail server hostname to send through
+    SENDER_EMAIL: From address for outgoing email
+
+Optional:
+    SMTP_PORT: Mail server port (defaults to 25)
 """
 
 import logging
+import os
 import smtplib
 from email.message import EmailMessage
 from email.policy import SMTP as SMTPPolicy
 
 logger = logging.getLogger(__name__)
 
-# Default SMTP server - Internal AI2 mail server
-DEFAULT_SMTP_SERVER = "smtp.example.com"
 DEFAULT_SMTP_PORT = 25
 
-# Default sender email
-DEFAULT_SENDER_EMAIL = "no-reply@allenai.org"
+
+class EmailError(Exception):
+    """Raised when email configuration or sending fails."""
+
+    pass
+
+
+def _require_env(name: str) -> str:
+    """Return the value of a required environment variable, or raise."""
+    value = os.environ.get(name)
+    if not value:
+        raise EmailError(f"Missing required environment variable: {name}")
+    return value
 
 
 def send_email(
     recipient_email: str,
     subject: str,
     body_html: str,
-    sender_email: str = DEFAULT_SENDER_EMAIL,
-    smtp_server: str = DEFAULT_SMTP_SERVER,
-    smtp_port: int = DEFAULT_SMTP_PORT,
+    sender_email: str | None = None,
+    smtp_server: str | None = None,
+    smtp_port: int | None = None,
 ) -> None:
     """Send an HTML email via SMTP.
 
@@ -32,13 +49,21 @@ def send_email(
         recipient_email: Recipient email address
         subject: Email subject line
         body_html: HTML email body
-        sender_email: Sender email address
-        smtp_server: SMTP server hostname
-        smtp_port: SMTP server port (default: 25)
+        sender_email: From address. Defaults to the SENDER_EMAIL env var.
+        smtp_server: SMTP server hostname. Defaults to the SMTP_SERVER env var.
+        smtp_port: SMTP server port. Defaults to the SMTP_PORT env var, then 25.
 
     Raises:
-        smtplib.SMTPException: If email sending fails
+        EmailError: If a required value (SENDER_EMAIL, SMTP_SERVER) is missing.
+        smtplib.SMTPException: If email sending fails.
     """
+    if sender_email is None:
+        sender_email = _require_env("SENDER_EMAIL")
+    if smtp_server is None:
+        smtp_server = _require_env("SMTP_SERVER")
+    if smtp_port is None:
+        smtp_port = int(os.environ.get("SMTP_PORT", DEFAULT_SMTP_PORT))
+
     msg = EmailMessage(policy=SMTPPolicy)
     msg["Subject"] = subject
     msg["From"] = sender_email

--- a/scripts/send_completion_emails.py
+++ b/scripts/send_completion_emails.py
@@ -10,6 +10,7 @@ Uses a GCS-based lock to prevent concurrent executions when scheduled frequently
 Environment variables required:
     - GCS credentials (for reading/writing job state)
     - AUTH0_MGMT_DOMAIN, AUTH0_MGMT_CLIENT_ID, AUTH0_MGMT_CLIENT_SECRET (for user email lookup)
+    - SMTP_SERVER, SENDER_EMAIL (mail server and from-address; SMTP_PORT optional, defaults to 25)
 """
 
 import argparse


### PR DESCRIPTION
## Problem

After the Auth0 fix (#20), the send-completion-emails job got past user lookup but then failed at the send step:

```
ERROR - Failed to send email for <user>/<run>: [Errno 8] nodename nor servname provided, or not known
```

`email.py` hardcoded ai2-specific defaults (`smtp.example.com`, `no-reply@allenai.org`) and the job never overrode the server, so every send tried to resolve the placeholder host and failed (DNS). Same scrub-placeholder class of bug as the Auth0 domain.

## Fix

Remove both defaults from the public repo and require `SMTP_SERVER` and `SENDER_EMAIL` from the environment (raising `EmailError` if unset), mirroring the `AUTH0_MGMT_*` vars. `SMTP_PORT` stays optional (defaults to 25). The real values are injected by deployment config.

- `email.py`: drop `DEFAULT_SMTP_SERVER` / `DEFAULT_SENDER_EMAIL`; resolve `SMTP_SERVER` / `SENDER_EMAIL` / `SMTP_PORT` from the environment via a `_require_env()` helper.
- `__init__.py`: stop exporting the removed defaults; export `EmailError`.
- `.env.example`: add `SMTP_SERVER` / `SENDER_EMAIL`.
- `send_completion_emails.py`: document the required vars.

## Import safety

The required-var checks are **lazy** — they run inside `send_email()`, not at import time. Importing the `autodiscovery_jobs` package (as the API app and the dataset-cleanup job do) needs no email config; only the email job, the sole caller of `send_email()`, does. Verified:

```
$ env -u SMTP_SERVER -u SENDER_EMAIL python -c "import autodiscovery_jobs; from autodiscovery_jobs import JobConfig, send_email"
import OK — no env vars needed
# send_email() raises only when actually called without config
```

## Deploy notes

The email Cloud Run jobs must set `SMTP_SERVER` and `SENDER_EMAIL` (in addition to `AUTH0_MGMT_DOMAIN`). The CI image auto-update only swaps `--image`, not env vars. Tracked on the deployment side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)