### PR TITLE
fix public sample dataset links

### DIFF
--- a/ui/src/app/runs/utils/preloadedDatasets.ts
+++ b/ui/src/app/runs/utils/preloadedDatasets.ts
@@ -53,20 +53,20 @@ export const PRELOADED_DATASETS: PreloadedDataset[] = [
         label: 'Tabula Sapiens - Heart',
         filename: 'heart.h5ad',
         description: datasetDescription,
-        url: 'gs://ai2-autodiscovery-public/CELLxGENE/heart.h5ad',
+        url: 'gs://ai2-autodiscovery/public/CELLxGENE/heart.h5ad',
     },
     {
         id: 'tabula-sapiens-kidney',
         label: 'Tabula Sapiens - Kidney',
         filename: 'kidney.h5ad',
         description: datasetDescription,
-        url: 'gs://ai2-autodiscovery-public/CELLxGENE/kidney.h5ad',
+        url: 'gs://ai2-autodiscovery/public/CELLxGENE/kidney.h5ad',
     },
     {
         id: 'tabula-sapiens-lung',
         label: 'Tabula Sapiens - Lung',
         filename: 'lung.h5ad',
         description: datasetDescription,
-        url: 'gs://ai2-autodiscovery-public/CELLxGENE/lung.h5ad',
+        url: 'gs://ai2-autodiscovery/public/CELLxGENE/lung.h5ad',
     },
 ];

--- a/ui/src/app/runs/utils/preloadedDatasets.ts
+++ b/ui/src/app/runs/utils/preloadedDatasets.ts
@@ -53,20 +53,20 @@ export const PRELOADED_DATASETS: PreloadedDataset[] = [
         label: 'Tabula Sapiens - Heart',
         filename: 'heart.h5ad',
         description: datasetDescription,
-        url: 'gs://ai2-autodiscovery/public/CELLxGENE/heart.h5ad',
+        url: 'gs://ai2-autodiscovery-public/CELLxGENE/heart.h5ad',
     },
     {
         id: 'tabula-sapiens-kidney',
         label: 'Tabula Sapiens - Kidney',
         filename: 'kidney.h5ad',
         description: datasetDescription,
-        url: 'gs://ai2-autodiscovery/public/CELLxGENE/kidney.h5ad',
+        url: 'gs://ai2-autodiscovery-public/CELLxGENE/kidney.h5ad',
     },
     {
         id: 'tabula-sapiens-lung',
         label: 'Tabula Sapiens - Lung',
         filename: 'lung.h5ad',
         description: datasetDescription,
-        url: 'gs://ai2-autodiscovery/public/CELLxGENE/lung.h5ad',
+        url: 'gs://ai2-autodiscovery-public/CELLxGENE/lung.h5ad',
     },
 ];

--- a/ui/src/app/runs/utils/preloadedDatasets.ts
+++ b/ui/src/app/runs/utils/preloadedDatasets.ts
@@ -53,20 +53,20 @@ export const PRELOADED_DATASETS: PreloadedDataset[] = [
         label: 'Tabula Sapiens - Heart',
         filename: 'heart.h5ad',
         description: datasetDescription,
-        url: 'gs://example-bucket/ai1/CELLxGENE/heart.h5ad',
+        url: 'gs://ai2-autodiscovery/public/CELLxGENE/heart.h5ad',
     },
     {
         id: 'tabula-sapiens-kidney',
         label: 'Tabula Sapiens - Kidney',
         filename: 'kidney.h5ad',
         description: datasetDescription,
-        url: 'gs://example-bucket/ai1/CELLxGENE/kidney.h5ad',
+        url: 'gs://ai2-autodiscovery/public/CELLxGENE/kidney.h5ad',
     },
     {
         id: 'tabula-sapiens-lung',
         label: 'Tabula Sapiens - Lung',
         filename: 'lung.h5ad',
         description: datasetDescription,
-        url: 'gs://example-bucket/ai1/CELLxGENE/lung.h5ad',
+        url: 'gs://ai2-autodiscovery/public/CELLxGENE/lung.h5ad',
     },
 ];


### PR DESCRIPTION
The bucket isn't publicly accessible and the name of it isn't particularly sensitive so these can stay where they are.

Long term I think we're likely to completely change how input files are widgetized and specified to agentic research systems, so this is really just keeping the current functionality intact with as little change as possible.