### PR TITLE
ci: dispatch private submodule bump to default branch, not main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,5 +93,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PRIVATE_DISPATCH_TOKEN }}
         run: |
+          # No --ref: dispatch against the private repo's default branch (its
+          # trunk), which is where the submodule bump + deploy should land. This
+          # follows the trunk automatically if the default branch ever changes.
           gh workflow run process-public-main-change.yml \
-            --repo allenai/asta-autodiscovery-private --ref main
+            --repo allenai/asta-autodiscovery-private


### PR DESCRIPTION
## Problem

The `notify-private` job in `ci.yml` dispatches the private repo's `process-public-main-change.yml` with `--ref main`:

```yaml
gh workflow run process-public-main-change.yml \
  --repo allenai/asta-autodiscovery-private --ref main
```

`--ref main` runs the **main** copy of that workflow, which pushes the submodule bump to the private repo's `main` branch. `main` still carries the pre-migration build/deploy pipeline, pointed at the old GCP project (`ai2-autodiscovery`). Its *Update Cloud Run Job* step then fails because the `-dev` jobs it targets only exist in the new project (`ai2-skiff2-autodiscovery`).

Result: every public-main advance produces two failed runs in the private repo (Build AutoDiscovery Image / Build Scripts Image).

## Fix

Drop `--ref` entirely. `gh workflow run` then dispatches against the private repo's **default branch** (currently `dev`), whose build workflows deploy to the new project and succeed. The private repo's `dev` copy of the bump workflow already pushes to `dev` — the dispatcher just never pointed at it.

Omitting `--ref` (rather than hardcoding `--ref dev`) means the bump always follows the private repo's trunk, even if its default-branch strategy changes later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)