### PR TITLE
Change name of Param to be more Generic

### DIFF
--- a/api/utils/asta_client.py
+++ b/api/utils/asta_client.py
@@ -63,7 +63,7 @@ def create_thread(
     Raises:
         requests.HTTPError: If the thread creation call fails
     """
-    body = {"autodiscovery_link": autodiscovery_link} if autodiscovery_link else {}
+    body = {"source_link": autodiscovery_link} if autodiscovery_link else {}
     _log.info("Asta create_thread request body: %s", body)
     resp = requests.put(
         f"{ASTA_BASE_URL}/api/chat/thread",


### PR DESCRIPTION
No need to change internal name - jut when making the call.