### PR TITLE
add rowIndex for heap analytics

### DIFF
--- a/ui/e2e/public-sample.spec.ts
+++ b/ui/e2e/public-sample.spec.ts
@@ -11,7 +11,7 @@ test.describe('Public shared sample', () => {
         await page.goto('/shared/samples/nls_bmi');
 
         // Wait for experiment rows to appear - confirms page fully rendered and API data loaded
-        await page.waitForSelector('[data-track-name="run_details__experiment-row"]', {
+        await page.waitForSelector('.MuiDataGrid-row', {
             timeout: 20000,
         });
 
@@ -22,7 +22,7 @@ test.describe('Public shared sample', () => {
         await expect(page.locator('text=Top Surprisals')).toBeVisible();
 
         // Click first experiment row and verify Belief Shift chart appears
-        await page.locator('[data-track-name="run_details__experiment-row"]').first().click();
+        await page.locator('.MuiDataGrid-row').first().click();
         await expect(page.locator('text=Belief Shift')).toBeVisible({ timeout: 10000 });
         await expect(page.locator('[data-testid="belief-distribution-plot"]')).toBeVisible();
     });

--- a/ui/src/app/analytics/runDetails.ts
+++ b/ui/src/app/analytics/runDetails.ts
@@ -4,7 +4,6 @@ const RUN_DETAILS = 'run_details' as const;
 
 // Experiment Row
 export const experimentRowEventName = `${RUN_DETAILS}__experiment-row` as const;
-export const mkExperimentRowAttrs = (props: {} = {}) => mkTrackAttrs(experimentRowEventName, props);
 
 // Session Configuration Button
 export const mkSessionConfigBtnAttrs = (props: { runId: string }) =>

--- a/ui/src/app/analytics/runDetails.ts
+++ b/ui/src/app/analytics/runDetails.ts
@@ -3,8 +3,8 @@ import { mkTrackAttrs } from '@/analytics/track';
 const RUN_DETAILS = 'run_details' as const;
 
 // Experiment Row
-export const mkExperimentRowAttrs = (props: {} = {}) =>
-    mkTrackAttrs(`${RUN_DETAILS}__experiment-row`, props);
+export const experimentRowEventName = `${RUN_DETAILS}__experiment-row` as const;
+export const mkExperimentRowAttrs = (props: {} = {}) => mkTrackAttrs(experimentRowEventName, props);
 
 // Session Configuration Button
 export const mkSessionConfigBtnAttrs = (props: { runId: string }) =>

--- a/ui/src/app/runs/components/ExperimentsTable.tsx
+++ b/ui/src/app/runs/components/ExperimentsTable.tsx
@@ -16,7 +16,6 @@ import { useExperimentBookmarks } from '@/contexts/ExperimentBookmarksContext';
 import { getPriorAndPosteriorLabel, getSurprisalDirection } from '@/runs/utils/ExperimentUtils';
 import {
     experimentRowEventName,
-    mkExperimentRowAttrs,
     mkExploreWithAstaTableLinkAttrs,
     sortColumnEventName,
 } from '@/analytics/runDetails';
@@ -496,7 +495,6 @@ export function ExperimentsTable({
                     rowSelectionModel={rowSelectionModel}
                     apiRef={apiRef}
                     slotProps={{
-                        row: mkExperimentRowAttrs(),
                         toolbar: {
                             csvOptions: { disableToolbarButton: true },
                             printOptions: { disableToolbarButton: true },

--- a/ui/src/app/runs/components/ExperimentsTable.tsx
+++ b/ui/src/app/runs/components/ExperimentsTable.tsx
@@ -5,6 +5,7 @@ import {
     GridRenderCellParams,
     GridRowSelectionModel,
     GridSortModel,
+    useGridApiRef,
 } from '@mui/x-data-grid';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -14,6 +15,7 @@ import { useRunExperiments } from '@/contexts/RunExperimentsContext';
 import { useExperimentBookmarks } from '@/contexts/ExperimentBookmarksContext';
 import { getPriorAndPosteriorLabel, getSurprisalDirection } from '@/runs/utils/ExperimentUtils';
 import {
+    experimentRowEventName,
     mkExperimentRowAttrs,
     mkExploreWithAstaTableLinkAttrs,
     sortColumnEventName,
@@ -37,6 +39,7 @@ export function ExperimentsTable({
     surprisalWidth,
     datasetExpired,
 }: ExperimentsTableProps) {
+    const apiRef = useGridApiRef();
     const { canExploreWithAsta } = useAuth0();
     const {
         experiments,
@@ -378,6 +381,12 @@ export function ExperimentsTable({
             // Don't allow clicking on skeleton rows
             if (params.row.isSkeleton) return;
 
+            // Send the row index as a custom prop to Heap
+            track(experimentRowEventName, {
+                rowindex: apiRef.current?.getRowIndexRelativeToVisibleRows(params.id),
+                experimentId: params.id,
+            });
+
             setVisitedIds((prev) => new Set(prev).add(params.id));
 
             const exp = experiments.find((exp) => exp.idInRun === params.id);
@@ -385,7 +394,7 @@ export function ExperimentsTable({
                 selectExperiment(exp, { scroll: false });
             }
         },
-        [experiments, selectExperiment]
+        [apiRef, experiments, selectExperiment]
     );
 
     // Scroll to the selected experiment when it changes, unless the caller opted out
@@ -485,6 +494,7 @@ export function ExperimentsTable({
                     onSortModelChange={handleSortModelChange}
                     getRowHeight={() => 'auto'}
                     rowSelectionModel={rowSelectionModel}
+                    apiRef={apiRef}
                     slotProps={{
                         row: mkExperimentRowAttrs(),
                         toolbar: {


### PR DESCRIPTION
For: https://github.com/allenai/nora-issues/issues/2650
Clicking a hypothesis row in autods now sends a `run_details__experiment-row` event to Heap with a rowindex property (plus experimentId), so we can analyze which rows users click.

I'm also removing the `data-track-name` and updating the tests, because after searching in Heap, I concluded: 
Searching for `run_details__download_btn` (the `data-track-name` event) returned nothing, while the slack thread mentioned `run_details__sort_column` (the `heap.track()` event) shows up. Therefore I removed it and updated the tests so we wouldn't have two mechanisms with only one working.

**Heap testing after merged**
Once deployed and a few rows have been clicked:
1. `run_details__experiment-row` appears in Heap with `rowindex` listed via Custom API (won't show until the first post-deploy click).
2. `rowindex` matches the clicked row's displayed position (0-based); experimentId matches the hypothesis.
3. Confirm sort-aware positioning is the intended semantic (it reflects current sort order, not a fixed experiment number).