### PR TITLE
make intent field the same height as the dataset schema

### DIFF
--- a/ui/src/app/runs/components/RunSetup.tsx
+++ b/ui/src/app/runs/components/RunSetup.tsx
@@ -327,6 +327,8 @@ export default function RunSetup({ runid, onSubmitSuccess }: RunSetupProps) {
                         hypothesis space, but can consider your areas of interest during generation.
                     </HelperText>
                     <TextField
+                        multiline
+                        rows={3}
                         value={settings.intent}
                         onChange={(e) => {
                             updateSettings('intent', e.target.value);


### PR DESCRIPTION
For: https://github.com/allenai/nora-issues/issues/3020#event-28135379199
The intent field now has 3 lines, same as the dataset schema field

Before: 
<img width="978" height="789" alt="Image" src="https://github.com/user-attachments/assets/2c9a60f4-bf63-4f43-bde2-956ee3600e68" /> 

After: 
<img width="952" height="239" alt="Screenshot 2026-07-17 at 1 49 25 PM" src="https://github.com/user-attachments/assets/9ecc2b11-dfa8-42f2-8a53-426826b7dd16" />
