### PR TITLE
Enable "Explore in Asta" for all users

### DIFF
--- a/api/runs/runs_api.py
+++ b/api/runs/runs_api.py
@@ -597,7 +597,6 @@ def create() -> Blueprint:
 
             # Check if user has permission for access in the UI
             has_ai1_datasets = PermissionType.AI1_DATASETS.value in permissions
-            has_asta_integration = PermissionType.ASTA_INTEGRATION.value in permissions
 
             # Compute dataset expiry
             dataset_expires_at = _compute_dataset_expires_at(run_details)
@@ -615,7 +614,7 @@ def create() -> Blueprint:
                 execution_status={},
                 max_file_size=max_file_size,
                 can_view_datasets=has_ai1_datasets,
-                can_explore_with_asta=has_asta_integration,
+                can_explore_with_asta=True,  # Enabled for all users (no longer permission-gated)
                 parent_run_id=(
                     run_metadata_model.parent_run_id if run_metadata_model else None
                 ),

--- a/ui/src/app/contexts/Auth0Context.tsx
+++ b/ui/src/app/contexts/Auth0Context.tsx
@@ -43,7 +43,6 @@ export interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-const ASTA_PERMISSION = 'enroll:asta_integration';
 const SESSION_STORAGE_KEY = 'ad_session_token';
 
 // ---------------------------------------------------------------------------
@@ -392,7 +391,9 @@ function useAuthValue(
             loginWithRedirect,
             logout,
             getAccessToken,
-            canExploreWithAsta: hasPermission(ASTA_PERMISSION),
+            // "Explore in Asta" is enabled for all users (no longer gated on
+            // the enroll:asta_integration permission).
+            canExploreWithAsta: true,
             authError,
             provider,
         };


### PR DESCRIPTION
## What

Enables the **"Explore / Continue exploring with Asta"** feature on AutoDiscovery for **all users**, removing the `enroll:asta_integration` Auth0 permission gate.

## Why

Requested by @smitar: roll the "explore in Asta" feature out to everyone.

## How it works today

UI visibility of the feature is driven entirely by `useAuth0().canExploreWithAsta`, used in `ExperimentsTable.tsx` and `ExperimentDetails.tsx`. That value was `hasPermission('enroll:asta_integration')`. The `dig-deeper` endpoint that actually performs the Asta handoff (`runs_api.py`) only checks `@requires_auth()` + caller identity — it never gated on the permission — so no backend authorization change is required.

## Changes

- **`ui/.../contexts/Auth0Context.tsx`**: `canExploreWithAsta` is now always `true`; dropped the now-unused `ASTA_PERMISSION` constant.
- **`api/runs/runs_api.py`**: the run model's `can_explore_with_asta` is now unconditionally `True` so the API reflects the same state; dropped the now-unused permission lookup.

No tests reference these flags. Leaving CI (`yarn build` + docker build) to validate the TS build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)