### PR TITLE
CI: run @public e2e on PRs and merges to main

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -7,8 +7,6 @@ version: 2
 
 secret:
   ignored-matches:
-    - name: Public Auth0 SPA client id (NEXT_PUBLIC_*, safe to ship in the browser)
-      match: 6EQ7FtDfVFMdGCWa8SMnGGX3W7p6XVNa
     - name: e2e password_file session secret (throwaway CI value in e2e-public.yml)
       match: ci-e2e-session-secret-not-a-real-secret-0123456789
     - name: e2e test-user password (throwaway CI value in e2e-public.yml)

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,15 @@
+# GitGuardian / ggshield configuration.
+# https://docs.gitguardian.com/ggshield-docs/reference/configuration
+#
+# Allowlist of known false positives — values that look like secrets but are
+# intentionally public or are throwaway CI test data.
+version: 2
+
+secret:
+  ignored-matches:
+    - name: Public Auth0 SPA client id (NEXT_PUBLIC_*, safe to ship in the browser)
+      match: 6EQ7FtDfVFMdGCWa8SMnGGX3W7p6XVNa
+    - name: e2e password_file session secret (throwaway CI value in e2e-public.yml)
+      match: ci-e2e-session-secret-not-a-real-secret-0123456789
+    - name: e2e test-user password (throwaway CI value in e2e-public.yml)
+      match: e2e-pass-123

--- a/.github/workflows/e2e-public.yml
+++ b/.github/workflows/e2e-public.yml
@@ -1,0 +1,101 @@
+name: E2E (public)
+
+# Runs the credential-free @public Playwright subset against a locally-composed,
+# bucket-less stack — one leg per auth provider. Uses no secrets, so it is safe on
+# PRs (including forks). The credentialed integration suite runs on internal infra.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  e2e-public:
+    name: E2E @public (${{ matrix.provider }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [none, password_file]
+    env:
+      # Mirror the public environment: no GCS bucket/credentials. GOOGLE_APPLICATION_
+      # CREDENTIALS points at /dev/null so the (unconditional) compose mount has a
+      # source that exists; GCS is never exercised by the @public tests.
+      AUTH_PROVIDER: ${{ matrix.provider }}
+      GCS_BUCKET: ""
+      GCP_PROJECT: ""
+      GOOGLE_APPLICATION_CREDENTIALS: /dev/null
+      # password_file config (ignored by the none provider). Ephemeral test values,
+      # not secrets.
+      AUTH_PASSWORD_DIR: ./secrets
+      AUTH_SESSION_SECRET: ci-e2e-session-secret-not-a-real-secret-0123456789
+      # Test hooks read by the specs.
+      E2E_AUTH_PROVIDER: ${{ matrix.provider }}
+      E2E_BASE_URL: http://localhost:8080
+      E2E_TEST_USER: e2e
+      E2E_TEST_PASSWORD: e2e-pass-123
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Prepare env
+        run: |
+          # docker-compose lists `.env` as an env_file; the checked-in symlink is
+          # dangling in CI, so replace it with an empty file. All config the stack
+          # needs comes from the compose `environment:` block + this job's env.
+          rm -f .env
+          : > .env
+          # Mount source for AUTH_PASSWORD_DIR must exist for both providers.
+          mkdir -p secrets
+
+      - name: Set up Python (seed helper)
+        if: matrix.provider == 'password_file'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Seed a test user (password_file)
+        if: matrix.provider == 'password_file'
+        run: |
+          pip install bcrypt
+          python api/scripts/auth_admin.py --dir ./secrets \
+            useradd "$E2E_TEST_USER" --email e2e@example.org --password "$E2E_TEST_PASSWORD"
+
+      - name: Start stack (bucket-less)
+        run: docker compose up -d --build proxy
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: yarn
+          cache-dependency-path: ui/yarn.lock
+
+      - name: Install UI dependencies
+        working-directory: ui
+        run: yarn install --frozen-lockfile
+
+      - name: Install Playwright (chromium)
+        working-directory: ui
+        run: yarn playwright install --with-deps chromium
+
+      - name: Run @public e2e
+        working-directory: ui
+        run: yarn test:e2e:public
+
+      - name: API logs on failure
+        if: failure()
+        run: docker compose logs api | tail -300
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.provider }}
+          path: ui/playwright-report
+          retention-days: 7
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/e2e-public.yml
+++ b/.github/workflows/e2e-public.yml
@@ -26,15 +26,14 @@ jobs:
       GCS_BUCKET: ""
       GCP_PROJECT: ""
       GOOGLE_APPLICATION_CREDENTIALS: /dev/null
-      # password_file config (ignored by the none provider). Ephemeral test values,
-      # not secrets.
+      # password_file store dir (ignored by the none provider). The session secret
+      # and test password are generated per-run (see the step below) rather than
+      # hard-coded, so no secret-shaped literals live in the repo.
       AUTH_PASSWORD_DIR: ./secrets
-      AUTH_SESSION_SECRET: ci-e2e-session-secret-not-a-real-secret-0123456789
       # Test hooks read by the specs.
       E2E_AUTH_PROVIDER: ${{ matrix.provider }}
       E2E_BASE_URL: http://localhost:8080
       E2E_TEST_USER: e2e
-      E2E_TEST_PASSWORD: e2e-pass-123
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -48,6 +47,13 @@ jobs:
           : > .env
           # Mount source for AUTH_PASSWORD_DIR must exist for both providers.
           mkdir -p secrets
+
+      - name: Generate ephemeral test credentials
+        run: |
+          # Per-run values so nothing secret-shaped is committed. Used by the
+          # password_file session signing + the seeded test user.
+          echo "AUTH_SESSION_SECRET=$(openssl rand -hex 32)" >> "$GITHUB_ENV"
+          echo "E2E_TEST_PASSWORD=$(openssl rand -hex 12)" >> "$GITHUB_ENV"
 
       - name: Set up Python (seed helper)
         if: matrix.provider == 'password_file'

--- a/.github/workflows/e2e-public.yml
+++ b/.github/workflows/e2e-public.yml
@@ -26,14 +26,15 @@ jobs:
       GCS_BUCKET: ""
       GCP_PROJECT: ""
       GOOGLE_APPLICATION_CREDENTIALS: /dev/null
-      # password_file store dir (ignored by the none provider). The session secret
-      # and test password are generated per-run (see the step below) rather than
-      # hard-coded, so no secret-shaped literals live in the repo.
+      # password_file config (ignored by the none provider). Throwaway CI test
+      # values, not real secrets — allowlisted in .gitguardian.yaml.
       AUTH_PASSWORD_DIR: ./secrets
+      AUTH_SESSION_SECRET: ci-e2e-session-secret-not-a-real-secret-0123456789
       # Test hooks read by the specs.
       E2E_AUTH_PROVIDER: ${{ matrix.provider }}
       E2E_BASE_URL: http://localhost:8080
       E2E_TEST_USER: e2e
+      E2E_TEST_PASSWORD: e2e-pass-123
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -47,13 +48,6 @@ jobs:
           : > .env
           # Mount source for AUTH_PASSWORD_DIR must exist for both providers.
           mkdir -p secrets
-
-      - name: Generate ephemeral test credentials
-        run: |
-          # Per-run values so nothing secret-shaped is committed. Used by the
-          # password_file session signing + the seeded test user.
-          echo "AUTH_SESSION_SECRET=$(openssl rand -hex 32)" >> "$GITHUB_ENV"
-          echo "E2E_TEST_PASSWORD=$(openssl rand -hex 12)" >> "$GITHUB_ENV"
 
       - name: Set up Python (seed helper)
         if: matrix.provider == 'password_file'


### PR DESCRIPTION
## What

Adds `.github/workflows/e2e-public.yml` — a public-safe e2e job that runs the credential-free **`@public`** Playwright subset against a locally-composed, **bucket-less** stack. Runs on `pull_request` → `main` and `push` → `main`.

A matrix leg per auth provider:
- **`none`** — asserts no sign-in affordance, already authenticated.
- **`password_file`** — login dialog opens; wrong password shows an inline error and does **not** trigger the global "Access Denied" dialog; a seeded user signs in and out.

## Why it's safe for the public repo

Uses **no secrets** (empty `.env`, no GCS bucket or credentials), so it's safe on PRs — including forks. The credentialed integration suite (real Auth0 + GCS + Modal) continues to run on internal infra, triggered from the private repo. This is the "public tier" of the two-tier split we designed.

## How each leg works

1. Empty `.env` (the checked-in symlink is dangling in CI) + bucket-less env (`GCS_BUCKET=""`, `GOOGLE_APPLICATION_CREDENTIALS=/dev/null`).
2. `password_file` only: seed an ephemeral test user via `api/scripts/auth_admin.py`.
3. `docker compose up -d --build proxy`.
4. `yarn playwright install --with-deps chromium` → `yarn test:e2e:public`.

## Validation

Ran both legs locally against a bucket-less stack before writing this:
- Stack builds and boots without GCS; `/api/auth/config` and `/api/user/me` work; `/api/runs/local/list` 500s (expected — no bucket).
- `none` spec: **passed** — `/runs` degrades gracefully despite the runs-list 500 (no white-screen).
- `password_file` specs: **all passed** — dialog / wrong-password / sign-in-out.
- Also confirmed the app boots with an **empty `.env`** (the exact CI condition).

## Notes

- Data-dependent specs (`public-sample`, `runs-pages`, `details-pages`) are intentionally **not** `@public` — they need GCS-backed sample data and stay internal-only.
- First run builds images (~a few min/leg); layer caching can be added later if it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)