### PR TITLE
Fix spurious 403 from userid="null" before auth bridge is wired (#51)

### DIFF
--- a/ui/e2e/auth-providers.spec.ts
+++ b/ui/e2e/auth-providers.spec.ts
@@ -88,4 +88,41 @@ test.describe('Auth: none provider (desktop mode)', { tag: '@public' }, () => {
         // And the logged-out intro CTA is not shown.
         await expect(page.getByRole('button', { name: /Sign in to get started/i })).toHaveCount(0);
     });
+
+    // Regression for issue #51: on a hard navigation to a run, the UI fired
+    // user-scoped requests with the literal string "null" as the user id before
+    // the auth bridge was wired (encodeURIComponent(null) === "null"), producing
+    // a spurious 403. Uses a synthetic run id so the test is data-independent —
+    // the bug fired the null request regardless of whether the run exists.
+    test('hard navigation to a run never issues /api/runs/null/...', async ({ page }) => {
+        const nullUserRequests: string[] = [];
+        const userIdSegments: string[] = [];
+        page.on('request', (req) => {
+            const { pathname } = new URL(req.url());
+            if (/^\/api\/runs\/null(\/|$)/.test(pathname)) {
+                nullUserRequests.push(pathname);
+            }
+            const match = pathname.match(/^\/api\/runs\/([^/]+)\//);
+            if (match && match[1] !== 'shared') {
+                userIdSegments.push(match[1]);
+            }
+        });
+
+        await page.goto('/runs/00000000-0000-0000-0000-000000000000', {
+            waitUntil: 'domcontentloaded',
+        });
+        // Wait until at least one user-scoped runs request has resolved, then a
+        // short buffer, so we observe what the page fired once auth hydrated.
+        await page.waitForResponse((r) => /^\/api\/runs\//.test(new URL(r.url()).pathname), {
+            timeout: 15000,
+        });
+        await page.waitForTimeout(500);
+
+        expect(
+            nullUserRequests,
+            `spurious "null" user-id requests: ${nullUserRequests.join(', ')}`
+        ).toEqual([]);
+        // The resolved id was the desktop local user, proving auth was ready.
+        expect(userIdSegments).toContain('local');
+    });
 });

--- a/ui/src/app/api/BaseApi.ts
+++ b/ui/src/app/api/BaseApi.ts
@@ -18,6 +18,21 @@ export class BaseApi {
         }
     };
 
+    /**
+     * Resolve the user id for a user-scoped request, preferring an explicitly
+     * provided id and falling back to the active auth provider. Throws when the
+     * id is not yet known so callers never interpolate the literal string
+     * "null" into a URL — `encodeURIComponent(null) === "null"`, which the
+     * backend rejects with a spurious 403 before auth hydrates. See issue #51.
+     */
+    protected requireUserId = async (provided?: string): Promise<string> => {
+        const userid = provided ?? (await this.getUserId());
+        if (userid == null || userid === '') {
+            throw new Error('Not signed in yet — user id is unavailable');
+        }
+        return userid;
+    };
+
     protected createDefaultHeaders = async (): Promise<{
         'Content-Type': string;
         Authorization?: string;

--- a/ui/src/app/api/RunsApi.ts
+++ b/ui/src/app/api/RunsApi.ts
@@ -204,24 +204,24 @@ export class RunsApi extends BaseApi {
     }
 
     async listRuns({ userid, limit }: { userid?: string; limit?: number } = {}) {
-        const effectiveUserid = userid ?? (await this.getUserId());
+        const effectiveUserid = await this.requireUserId(userid);
 
         const query: Record<string, string> = {};
         if (limit) {
             query.limit = limit.toString();
         }
         return this.request<GetViewerRunsResponseBody>({
-            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(effectiveUserid!)}/list`,
+            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(effectiveUserid)}/list`,
             method: 'GET',
             query,
         });
     }
 
     async getRunMetadata({ userid, runid }: { userid?: string; runid: string }) {
-        const effectiveUserid = userid ?? (await this.getUserId());
+        const effectiveUserid = await this.requireUserId(userid);
 
         return this.request<GetRunMetadataResponseBody>({
-            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(effectiveUserid!)}/${encodeURIComponent(runid)}/metadata`,
+            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(effectiveUserid)}/${encodeURIComponent(runid)}/metadata`,
             method: 'GET',
         });
     }
@@ -235,10 +235,10 @@ export class RunsApi extends BaseApi {
         runid: string;
         knownExperimentIds: string[];
     }) {
-        const effectiveUserid = userid ?? (await this.getUserId());
+        const effectiveUserid = await this.requireUserId(userid);
 
         return this.request<GetRunExperimentsResponseBody>({
-            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(effectiveUserid!)}/${encodeURIComponent(runid)}/experiments`,
+            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(effectiveUserid)}/${encodeURIComponent(runid)}/experiments`,
             method: 'POST',
             body: { known_experiment_ids: knownExperimentIds },
         });
@@ -253,10 +253,10 @@ export class RunsApi extends BaseApi {
         runid: string;
         experimentId: string;
     }) {
-        const effectiveUserid = userid ?? (await this.getUserId());
+        const effectiveUserid = await this.requireUserId(userid);
 
         return this.request<GetRunExperimentDetailsResponseBody>({
-            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(effectiveUserid!)}/${encodeURIComponent(runid)}/experiments/${encodeURIComponent(
+            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(effectiveUserid)}/${encodeURIComponent(runid)}/experiments/${encodeURIComponent(
                 experimentId
             )}`,
             method: 'GET',
@@ -264,27 +264,27 @@ export class RunsApi extends BaseApi {
     }
 
     async getRun({ userid, runId }: { userid?: string; runId: string }) {
-        const effectiveUserid = userid ?? (await this.getUserId());
+        const effectiveUserid = await this.requireUserId(userid);
 
         return this.request<RunResponseBody>({
-            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(effectiveUserid!)}/${encodeURIComponent(runId)}`,
+            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(effectiveUserid)}/${encodeURIComponent(runId)}`,
             method: 'GET',
         });
     }
 
     async getRunStatus({ userid, runId }: { userid?: string; runId: string }) {
-        const effectiveUserid = userid ?? (await this.getUserId());
+        const effectiveUserid = await this.requireUserId(userid);
 
         return this.request<RunResponseBody>({
-            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(effectiveUserid!)}/${encodeURIComponent(runId)}/status`,
+            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(effectiveUserid)}/${encodeURIComponent(runId)}/status`,
             method: 'GET',
         });
     }
 
     async cancelRun(runId: string) {
-        const userid = await this.getUserId();
+        const userid = await this.requireUserId();
         return this.request<void>({
-            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(userid!)}/${encodeURIComponent(runId)}/cancel`,
+            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(userid)}/${encodeURIComponent(runId)}/cancel`,
             method: 'POST',
         });
     }
@@ -347,9 +347,9 @@ export class RunsApi extends BaseApi {
     }
 
     async shareRun({ runId, isShared }: { runId: string; isShared: boolean }) {
-        const userid = await this.getUserId();
+        const userid = await this.requireUserId();
         return this.request<ShareRunResponseBody>({
-            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(userid!)}/${encodeURIComponent(runId)}/share`,
+            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(userid)}/${encodeURIComponent(runId)}/share`,
             method: 'POST',
             body: { is_shared: isShared },
         });
@@ -363,9 +363,9 @@ export class RunsApi extends BaseApi {
     }
 
     async bookmarkRun({ runId, isBookmarked }: { runId: string; isBookmarked: boolean }) {
-        const userid = await this.getUserId();
+        const userid = await this.requireUserId();
         return this.request<BookmarkRunResponseBody>({
-            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(userid!)}/${encodeURIComponent(runId)}/bookmark`,
+            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(userid)}/${encodeURIComponent(runId)}/bookmark`,
             method: 'POST',
             body: { is_bookmarked: isBookmarked },
         });
@@ -380,9 +380,9 @@ export class RunsApi extends BaseApi {
         experimentId: string;
         isBookmarked: boolean;
     }) {
-        const userid = await this.getUserId();
+        const userid = await this.requireUserId();
         return this.request<BookmarkExperimentResponseBody>({
-            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(userid!)}/${encodeURIComponent(runId)}/experiments/${encodeURIComponent(experimentId)}/bookmark`,
+            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(userid)}/${encodeURIComponent(runId)}/experiments/${encodeURIComponent(experimentId)}/bookmark`,
             method: 'POST',
             body: { is_bookmarked: isBookmarked },
         });
@@ -397,9 +397,9 @@ export class RunsApi extends BaseApi {
         experimentId: string;
         query: string;
     }) {
-        const userid = await this.getUserId();
+        const userid = await this.requireUserId();
         return this.request<DigDeeperResponseBody>({
-            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(userid!)}/${encodeURIComponent(runId)}/experiments/${encodeURIComponent(experimentId)}/dig-deeper`,
+            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(userid)}/${encodeURIComponent(runId)}/experiments/${encodeURIComponent(experimentId)}/dig-deeper`,
             method: 'POST',
             body: { query },
         });

--- a/ui/src/app/contexts/Auth0Context.tsx
+++ b/ui/src/app/contexts/Auth0Context.tsx
@@ -288,7 +288,12 @@ function PasswordFileAuthProvider({ children }: { children: ReactNode }) {
         return token;
     }, [token]);
 
-    useEffect(() => {
+    // Wire the bridge during render (not in a useEffect) so it reflects the
+    // restored session before children commit and fire requests. Wiring in an
+    // effect leaves the same null-user-id window as the "none" provider had: the
+    // commit that flips isAuthenticated true runs child effects (which fetch)
+    // before this provider's bridge effect updates getUserId. See #51.
+    useMemo(() => {
         setAuthBridge({
             getToken: async () => token,
             getUserId: async () => user?.sub ?? null,
@@ -335,13 +340,20 @@ const LOCAL_USER: AuthUser = {
 };
 
 function NoneAuthProvider({ children }: { children: ReactNode }) {
-    useEffect(() => {
+    // Wire the bridge synchronously on the first render — before any child effect
+    // can fire a user-id-bearing request. This provider reports `isAuthenticated:
+    // true, isLoading: false` synchronously, so if the bridge were wired in a
+    // useEffect (which runs after the first commit) a hard navigation to
+    // /runs/<id> would issue /api/runs/null/... and get a spurious 403 while the
+    // bridge still returned the default null. The values are static, so wiring
+    // once via a lazy state initializer (runs during render) is enough. See #51.
+    useState(() => {
         setAuthBridge({
             getToken: async () => null,
             getUserId: async () => LOCAL_USER.sub ?? null,
             onUnauthorized: () => {},
         });
-    }, []);
+    });
 
     const value = useMemo<AuthContextType>(
         () => ({


### PR DESCRIPTION
Fixes #51.

## Problem

With `AUTH_PROVIDER=none`, hard-navigating to `/runs/<id>` briefly showed **"Request failed with status 403: User cannot view other user's data"** — even for the user's own runs. The UI fired requests with the literal string `null` as the user id before the id was known:

```
GET /api/runs/null/list      -> 403
GET /api/runs/null/<runid>   -> 403   <- banner
GET /api/runs/local/<runid>  -> 200   <- once auth hydrates
```

`encodeURIComponent(null) === "null"`, and a `!` non-null assertion hid that the id was still null. The window existed only for `none` because it reported `isAuthenticated: true` / `isLoading: false` synchronously while wiring its `getUserId` bridge in a `useEffect` that runs after the first commit.

## Fix (two layers)

**1. Wire the `getUserId` bridge before readiness is reported** (`Auth0Context.tsx`)
- `NoneAuthProvider`: wire during render (lazy `useState` initializer) instead of in a post-commit `useEffect`.
- `PasswordFileAuthProvider`: had the same latent race — its bridge effect updated `getUserId` *after* the commit that flips `isAuthenticated` true, so child fetches ran first. Now wired during render.
- `Auth0AuthProvider`: unchanged — already keeps `isLoading: true` until the user id is known.

**2. Guard `RunsApi` (belt-and-suspenders)** (`BaseApi.ts`, `RunsApi.ts`)
- `BaseApi.requireUserId()` throws a clear error when the id is null/empty instead of interpolating `"null"` into the URL. Removed all `effectiveUserid!` / `userid!` assertions (11 call sites).

## Verification
- Added a `@public` regression e2e test (`auth-providers.spec.ts`, `none` block) using a synthetic, data-independent run id. **Fails without the fix** (captures `/api/runs/null/...`), **passes with it**.
- Reproduced and verified against the live `none` stack; full `none` suite passes; `yarn ts-check` and `yarn lint` clean.

Acceptance criteria met: no `/api/runs/null/...` under `AUTH_PROVIDER=none`, no user-id-bearing request before the id resolves, `auth0` behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)