### PR TITLE
Scope Docker job GCS mount to the run's own prefix (#49)

### DIFF
--- a/packages/autodiscovery/docker-entrypoint.sh
+++ b/packages/autodiscovery/docker-entrypoint.sh
@@ -9,12 +9,26 @@
 # gs://$GCSFUSE_BUCKET at /mnt/gcs (authenticating via GOOGLE_APPLICATION_CREDENTIALS)
 # before the job starts. gcsfuse requires the /dev/fuse device and CAP_SYS_ADMIN,
 # which the Docker backend grants when launching the container.
+#
+# When GCSFUSE_ONLY_DIR is also set, the mount is scoped to just that prefix
+# (this run's users/<uid>/jobs/<jid>) for least-privilege tenant isolation: the
+# container then cannot see or modify other users' data through the filesystem.
+# The scoped subtree is mounted at its full path (/mnt/gcs/$GCSFUSE_ONLY_DIR) so
+# the job's existing absolute --dataset_metadata / --out_dir args still resolve.
 set -e
 
 if [ -n "${GCSFUSE_BUCKET}" ]; then
-    echo "Mounting gs://${GCSFUSE_BUCKET} at /mnt/gcs via gcsfuse..."
-    mkdir -p /mnt/gcs
-    gcsfuse --implicit-dirs "${GCSFUSE_BUCKET}" /mnt/gcs
+    if [ -n "${GCSFUSE_ONLY_DIR}" ]; then
+        # Quote GCSFUSE_ONLY_DIR everywhere: user ids can contain a '|' char,
+        # which is a valid path character but shell-special when unquoted.
+        echo "Mounting gs://${GCSFUSE_BUCKET}/${GCSFUSE_ONLY_DIR} at /mnt/gcs/${GCSFUSE_ONLY_DIR} via gcsfuse..."
+        mkdir -p "/mnt/gcs/${GCSFUSE_ONLY_DIR}"
+        gcsfuse --implicit-dirs --only-dir "${GCSFUSE_ONLY_DIR}" "${GCSFUSE_BUCKET}" "/mnt/gcs/${GCSFUSE_ONLY_DIR}"
+    else
+        echo "Mounting gs://${GCSFUSE_BUCKET} at /mnt/gcs via gcsfuse..."
+        mkdir -p /mnt/gcs
+        gcsfuse --implicit-dirs "${GCSFUSE_BUCKET}" /mnt/gcs
+    fi
 fi
 
 exec /root/.local/bin/uv run python -m autodiscovery.run "$@"

--- a/packages/autodiscovery/scripts/rebuild_and_deploy.sh
+++ b/packages/autodiscovery/scripts/rebuild_and_deploy.sh
@@ -88,6 +88,13 @@ UPDATE_SECRETS=(
 )
 
 UPDATE_SECRETS_ARG=$(IFS=,; echo "${UPDATE_SECRETS[*]}")
+# NOTE (tenant isolation, issue #49): this mounts the WHOLE bucket at /mnt/gcs,
+# so a job container can read/write any user's prefix via the filesystem. The
+# mount cannot be scoped to a run's own users/<uid>/jobs/<jid> prefix here
+# because it is defined on the shared job resource and per-execution overrides
+# (RunJobRequest.Overrides) cover only container args/env, not volumes/only-dir.
+# Per-run scoping would require a distinct per-run job definition. The local
+# Docker backend, which self-mounts, is scoped per-run via GCSFUSE_ONLY_DIR.
 gcloud run jobs update ${JOB_NAME} \
     --region ${REGION} \
     --image ${IMAGE} \

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/docker.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/docker.py
@@ -7,9 +7,11 @@ continues to use Modal for its code-execution sandboxes — only the process
 launcher differs.
 
 Because there is no Cloud Run GCS FUSE volume locally, the job container mounts
-the real bucket at ``/mnt/gcs`` itself via gcsfuse in its entrypoint. This
-backend enables that by passing ``GCSFUSE_BUCKET`` plus GCP credentials and the
-``/dev/fuse`` device / ``SYS_ADMIN`` capability to the container.
+the bucket itself via gcsfuse in its entrypoint. This backend enables that by
+passing ``GCSFUSE_BUCKET`` plus GCP credentials and the ``/dev/fuse`` device /
+``SYS_ADMIN`` capability to the container. The mount is scoped to this run's own
+``users/<uid>/jobs/<jid>`` prefix (via ``GCSFUSE_ONLY_DIR``) so a job container
+cannot see or modify other users' data through ``/mnt/gcs``.
 """
 
 from __future__ import annotations
@@ -87,6 +89,10 @@ class DockerBackend(JobBackend):
             k: os.environ[k] for k in _JOB_ENV_PASSTHROUGH if os.environ.get(k)
         }
         environment["GCSFUSE_BUCKET"] = self.config.bucket
+        # Scope the gcsfuse mount to just this run's prefix (least privilege /
+        # tenant isolation) — the entrypoint mounts it at /mnt/gcs/<only-dir>,
+        # matching the absolute paths build_job_args() hands the job.
+        environment["GCSFUSE_ONLY_DIR"] = f"users/{userid}/jobs/{jobid}"
         environment["GOOGLE_APPLICATION_CREDENTIALS"] = _CONTAINER_GCP_KEY_PATH
 
         # Bind-mount the GCP credentials file so gcsfuse (and google-cloud

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/gcp.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/gcp.py
@@ -102,7 +102,20 @@ def run_job(
         # Create JobsClient and run the job
         client = run_v2.JobsClient()
 
-        # Create request with container argument overrides
+        # Create request with container argument overrides.
+        #
+        # Known limitation (tenant isolation, issue #49): the GCS bucket is
+        # mounted whole at /mnt/gcs by the shared Cloud Run job definition (see
+        # scripts/rebuild_and_deploy.sh), so a job container can read/write any
+        # user's prefix through the filesystem. We cannot scope the mount to
+        # this run's own users/<uid>/jobs/<jid> prefix here because per-execution
+        # RunJobRequest.Overrides only cover container args/env/task_count/timeout
+        # — NOT volumes or volume mounts (there is no `only-dir` override). Real
+        # per-run scoping would require a distinct per-run job definition
+        # (create/patch), which adds launch latency and lifecycle management.
+        # The Docker backend, which self-mounts, is scoped per-run via
+        # GCSFUSE_ONLY_DIR; the Modal code-execution sandbox is separately
+        # scoped read-only to the per-job .../data prefix.
         request = run_v2.RunJobRequest(
             name=job_name,
             overrides=run_v2.RunJobRequest.Overrides(

--- a/packages/autodiscovery_jobs/tests/test_backends.py
+++ b/packages/autodiscovery_jobs/tests/test_backends.py
@@ -102,6 +102,8 @@ def test_docker_run_job_launches_container(docker_config, monkeypatch):
     assert "--model=gpt-4o" in kwargs["command"]
     # gcsfuse trigger + credentials forwarded
     assert kwargs["environment"]["GCSFUSE_BUCKET"] == "test-bucket"
+    # mount scoped to this run's own prefix (tenant isolation, issue #49)
+    assert kwargs["environment"]["GCSFUSE_ONLY_DIR"] == "users/testuser/jobs/job1"
     assert kwargs["environment"]["OPENAI_API_KEY"] == "sk-test"
     assert kwargs["environment"]["MODAL_TOKEN_ID"] == "tok"
     assert kwargs["environment"]["GOOGLE_APPLICATION_CREDENTIALS"] == "/secrets/gcp-key.json"
@@ -110,6 +112,20 @@ def test_docker_run_job_launches_container(docker_config, monkeypatch):
     assert "SYS_ADMIN" in kwargs["cap_add"]
     # host credentials bind-mounted into the job container
     assert "/host/secrets/gcp-key.json" in kwargs["volumes"]
+
+
+def test_docker_run_job_scopes_mount_for_pipe_userid(docker_config, monkeypatch):
+    # User ids can contain '|' (e.g. auth0 "oauth2|123"); it must flow through
+    # to GCSFUSE_ONLY_DIR verbatim (the entrypoint quotes it for the shell).
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    client = Mock()
+    with patch("autodiscovery_jobs.backends.docker._docker_client", return_value=client):
+        backend = DockerBackend(docker_config)
+        backend.run_job("google-oauth2|42", "job1", n_experiments=1)
+
+    kwargs = client.containers.run.call_args.kwargs
+    assert kwargs["environment"]["GCSFUSE_ONLY_DIR"] == "users/google-oauth2|42/jobs/job1"
 
 
 def test_docker_run_job_requires_image(monkeypatch):


### PR DESCRIPTION
Closes #49.

## Why
The Docker job backend self-mounts the GCS bucket at `/mnt/gcs` via gcsfuse, mounting the **whole** bucket. A job only ever reads/writes its own `users/<uid>/jobs/<jid>` prefix, so the whole-bucket mount lets any job container read/write every user's data through the filesystem. This scopes the mount to the run's own prefix (least privilege / tenant isolation).

> Stacked on `swappable-job-backend` (#30), since that's where the Docker backend and entrypoint live. Merge after / retarget once #30 lands.

## Docker backend (scoped)
- `DockerBackend` passes `GCSFUSE_ONLY_DIR=users/<uid>/jobs/<jid>`.
- `docker-entrypoint.sh` mounts the scoped subtree at its **full path** (`/mnt/gcs/$GCSFUSE_ONLY_DIR`) with `gcsfuse --implicit-dirs --only-dir`, so the job's existing absolute `--dataset_metadata` / `--out_dir` args still resolve and `build_job_args` is unchanged.
- `GCSFUSE_ONLY_DIR` is quoted everywhere in the entrypoint — user ids can contain `|`, a valid path char that's shell-special unquoted. Added a test with a `|`-containing user id.

## Cloud Run backend (documented limitation)
Per the issue's open design question: the FUSE volume is defined on the **shared** Cloud Run job resource, and per-execution `RunJobRequest.Overrides` cover only `container_overrides` (args/env), `task_count`, and `timeout` — **not** volumes or a `only-dir` mount option (verified against `google-cloud-run`). So a single shared job definition can't carry a per-run `only-dir`; real per-run scoping would require a distinct per-run job definition (create/patch — added latency + lifecycle). This is documented inline in `gcp.py` and `scripts/rebuild_and_deploy.sh` rather than implemented. (The Modal code-execution sandbox is separately scoped read-only to the per-job `.../data` prefix — out of scope here.)

## Acceptance criteria
- [x] Docker: job container can read/write only its own prefix via `/mnt/gcs`; other prefixes are not visible.
- [x] Cloud Run: chosen approach/limitation documented.

## Testing
- `pytest tests/test_backends.py` — 21 passed (adds scoped-mount assertion + `|`-userid case).
- `ruff check` / `ruff format --check` clean; `sh -n` / `bash -n` on both scripts pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)