### PR TITLE
Configurable code-execution backend (CODE_EXECUTION_BACKEND)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,13 +22,27 @@ JOB_BACKEND=docker
 # `docker compose build autodiscovery` (tags it as this value).
 AUTODISCOVERY_IMAGE=autodiscovery:dev
 
+# Code-execution backend for the AD job's LLM-generated code:
+#   process (default) - isolated subprocess inside the job container; no cloud
+#                       dependency (Modal not required). Reads the dataset from
+#                       the job's /mnt/gcs mount.
+#   local             - in-process, no isolation.
+#   modal             - remote Modal sandbox; mounts only the per-job data,
+#                       read-only. Required for multi-user GCP deployments.
+# Untrusted generated code runs wherever the data is mounted, so this interacts
+# with JOB_BACKEND and AUTH_PROVIDER. See docs/configuration.md for the safe
+# combinations before changing it for a multi-user deployment.
+CODE_EXECUTION_BACKEND=process
+
 MODAL_TOKEN_ID=...
 MODAL_TOKEN_SECRET=...
 MODAL_IMAGE_BUILDER_VERSION=2025.06
 MODAL_ENVIRONMENT=AutoDiscovery
 # Name of the Modal secret holding the GCS credentials the sandbox uses to mount
-# datasets. Required: must name a real secret in MODAL_ENVIRONMENT, or every run
-# fails at sandbox creation with "Secret '...' not found".
+# datasets. Required only when CODE_EXECUTION_BACKEND=modal: it must name a real
+# secret in MODAL_ENVIRONMENT, or every run fails at sandbox creation with
+# "Secret '...' not found". Unused (and the MODAL_* vars above are unused) with
+# the default process/local code-execution backend.
 MODAL_BUCKET_SECRET=...
 # Modal app the sandboxes run under (created on demand). Override if needed.
 # MODAL_APP_NAME=asta-autodiscovery

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,6 +68,10 @@ services:
       - JOB_BACKEND=${JOB_BACKEND:-docker}
       # Image the docker backend launches per job (built via `docker compose build autodiscovery`).
       - AUTODISCOVERY_IMAGE=${AUTODISCOVERY_IMAGE:-autodiscovery:dev}
+      # Code-execution backend for the AD job's generated code: process (default,
+      # isolated subprocess, no cloud dep) | local (in-process) | modal (remote
+      # scoped sandbox). See docs/configuration.md for the safe-combination matrix.
+      - CODE_EXECUTION_BACKEND=${CODE_EXECUTION_BACKEND:-process}
       # Host path of the GCP key, derived from GOOGLE_APPLICATION_CREDENTIALS so the
       # docker backend can bind-mount it into each job container (the in-container
       # GOOGLE_APPLICATION_CREDENTIALS above is a container path, unusable as a host

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,29 +93,70 @@ docker compose build autodiscovery
 docker compose up
 ```
 
-The job container mounts the GCS bucket at `/mnt/gcs` itself via gcsfuse (triggered by
+The job container mounts its GCS data at `/mnt/gcs` itself via gcsfuse (triggered by
 `GCSFUSE_BUCKET`, which the backend sets from `GCS_BUCKET`); on Cloud Run the platform provides
-that mount instead.
+that mount instead. The docker backend scopes the mount to the run's own prefix
+(`users/<uid>/jobs/<jid>`), so a job container never sees other users' data — see
+[Code-execution backend](#code-execution-backend) for why that matters.
 
 To run jobs on Cloud Run instead, set `JOB_BACKEND=gcp` (the Docker socket mount is then unused).
 
 > **Security note.** The docker backend gives the API access to the host Docker socket, which is
 > effectively root on the host. This is fine for local/single-user use, but for a shared,
 > multi-user deployment (e.g. `AUTH_PROVIDER=password_file`) prefer `JOB_BACKEND=gcp`, where the
-> API only holds scoped cloud credentials. The job's data view is identical either way.
+> API only holds scoped cloud credentials.
 
-## Modal (code-execution sandbox)
+## Code-execution backend
 
-AutoDiscovery runs execute generated code inside Modal sandboxes.
+The AD job runs the LLM-generated experiment code through a configurable executor, selected with
+`CODE_EXECUTION_BACKEND` and forwarded to the job's `--backend` flag:
 
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
-| `MODAL_TOKEN_ID` | Yes | *(none)* | Modal API token id. |
-| `MODAL_TOKEN_SECRET` | Yes | *(none)* | Modal API token secret. |
-| `MODAL_ENVIRONMENT` | Yes | *(none)* | Modal environment name to run sandboxes in. |
+| `CODE_EXECUTION_BACKEND` | No | `process` | `process` (isolated subprocess in the job container), `local` (in-process, no isolation), or `modal` (remote sandbox). |
+
+- `process` (default) — runs code in an isolated subprocess inside the job container, in a separate
+  sandbox venv; per-cell package installs are discarded, and no state carries across cells. No cloud
+  dependency (Modal is not required). Reads the dataset from the job's `/mnt/gcs` mount.
+- `local` — runs code in-process with no isolation. Lowest overhead, least safe.
+- `modal` — runs code in a remote Modal sandbox that mounts **only** the per-job data prefix,
+  read-only. Requires the [Modal](#modal-code-execution-sandbox-backend) variables.
+
+### Choosing a safe combination
+
+`process`/`local` execute untrusted, generated code **inside the job container**, so that code can
+read whatever GCS data the container mounts. `modal` instead runs it on a separate machine with only
+the per-job data mounted read-only. Whether in-process execution is safe therefore depends on the
+job backend (how the mount is scoped) and on whether the deployment is multi-user:
+
+| Job backend | Code backend | Single user (`AUTH_PROVIDER=none`) | Multi-user (`auth0` / `password_file`) |
+| --- | --- | --- | --- |
+| `docker` | `process` / `local` | ✅ safe | ✅ safe — mount is scoped to the job's own prefix |
+| `gcp` | `process` / `local` | ✅ safe | ⚠️ **unsafe** — Cloud Run mounts the whole bucket; executed code can read every user's data |
+| `docker` / `gcp` | `modal` | ✅ safe | ✅ safe — scoped, read-only per-job data mount |
+
+The unsafe combination arises because Cloud Run's GCS mount is fixed per job (it cannot be scoped
+per execution), while the docker backend re-mounts only the current job's prefix each run. The API
+logs a loud warning at startup for the unsafe combination; set `CODE_EXECUTION_BACKEND=modal` for
+multi-user Cloud Run deployments.
+
+> Within a single job, `process`/`local` mount the job's own data read-write (the run also writes its
+> output there), so generated code could overwrite that job's own inputs. This is within-tenant only;
+> `modal` mounts the data read-only.
+
+## Modal (code-execution sandbox backend)
+
+Used only when `CODE_EXECUTION_BACKEND=modal`. With the default `process` (or `local`) backend the
+`MODAL_*` variables are unused.
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `MODAL_TOKEN_ID` | modal | *(none)* | Modal API token id. |
+| `MODAL_TOKEN_SECRET` | modal | *(none)* | Modal API token secret. |
+| `MODAL_ENVIRONMENT` | modal | *(none)* | Modal environment name to run sandboxes in. |
 | `MODAL_IMAGE_BUILDER_VERSION` | No | *(Modal default)* | Pins the Modal image builder version used to build sandbox images. |
 | `MODAL_APP_NAME` | No | `asta-autodiscovery` | Modal app name the sandboxes are associated with. Created on demand if it doesn't exist. |
-| `MODAL_BUCKET_SECRET` | Yes | `example-bucket-secret` | Name of the Modal [secret](https://modal.com/docs/guide/secrets) holding the GCS credentials the sandbox uses to mount dataset files. The default is a **placeholder that does not exist** — you must set this to the name of a real secret in your `MODAL_ENVIRONMENT`, or every run fails at sandbox creation with `Secret '…' not found`. |
+| `MODAL_BUCKET_SECRET` | modal | `example-bucket-secret` | Name of the Modal [secret](https://modal.com/docs/guide/secrets) holding the GCS credentials the sandbox uses to mount dataset files. The default is a **placeholder that does not exist** — you must set this to the name of a real secret in your `MODAL_ENVIRONMENT`, or every run fails at sandbox creation with `Secret '…' not found`. |
 
 ## LLM providers
 

--- a/packages/autodiscovery/docker-entrypoint.sh
+++ b/packages/autodiscovery/docker-entrypoint.sh
@@ -9,12 +9,24 @@
 # gs://$GCSFUSE_BUCKET at /mnt/gcs (authenticating via GOOGLE_APPLICATION_CREDENTIALS)
 # before the job starts. gcsfuse requires the /dev/fuse device and CAP_SYS_ADMIN,
 # which the Docker backend grants when launching the container.
+#
+# When GCSFUSE_ONLY_DIR is set (e.g. users/<uid>/jobs/<jid>), only that prefix is
+# mounted, at the matching deep path under /mnt/gcs, so the job sees only its own
+# data even when code executes in-process. This keeps other users' workspaces out
+# of the container. Without it, the whole bucket is mounted at /mnt/gcs.
 set -e
 
 if [ -n "${GCSFUSE_BUCKET}" ]; then
-    echo "Mounting gs://${GCSFUSE_BUCKET} at /mnt/gcs via gcsfuse..."
-    mkdir -p /mnt/gcs
-    gcsfuse --implicit-dirs "${GCSFUSE_BUCKET}" /mnt/gcs
+    if [ -n "${GCSFUSE_ONLY_DIR}" ]; then
+        mountpoint="/mnt/gcs/${GCSFUSE_ONLY_DIR}"
+        echo "Mounting gs://${GCSFUSE_BUCKET}/${GCSFUSE_ONLY_DIR} at ${mountpoint} via gcsfuse..."
+        mkdir -p "${mountpoint}"
+        gcsfuse --implicit-dirs --only-dir "${GCSFUSE_ONLY_DIR}" "${GCSFUSE_BUCKET}" "${mountpoint}"
+    else
+        echo "Mounting gs://${GCSFUSE_BUCKET} at /mnt/gcs via gcsfuse..."
+        mkdir -p /mnt/gcs
+        gcsfuse --implicit-dirs "${GCSFUSE_BUCKET}" /mnt/gcs
+    fi
 fi
 
 exec /root/.local/bin/uv run python -m autodiscovery.run "$@"

--- a/packages/autodiscovery/src/autodiscovery/agents.py
+++ b/packages/autodiscovery/src/autodiscovery/agents.py
@@ -193,21 +193,21 @@ class ModalSandboxExecutor(CodeExecutor):
         """
         code = "\n".join(block.code for block in code_blocks)
 
-        print("\n[ModalSandboxExecutor] Executing code in sandbox...")
-        print(f"[ModalSandboxExecutor] Code length: {len(code)} characters")
+        print("\n[CodeExecutor] Executing code in sandbox...")
+        print(f"[CodeExecutor] Code length: {len(code)} characters")
 
         try:
             result = _run_async(self._executor.run_code(code, timeout_seconds=self._timeout))
 
-            print("[ModalSandboxExecutor] Execution completed")
-            print(f"[ModalSandboxExecutor] Success: {result.success}")
+            print("[CodeExecutor] Execution completed")
+            print(f"[CodeExecutor] Success: {result.success}")
 
             output = result.stdout or ""
 
-            print(f"[ModalSandboxExecutor] Stdout length: {len(output)} characters")
+            print(f"[CodeExecutor] Stdout length: {len(output)} characters")
 
             if result.stderr:
-                print(f"[ModalSandboxExecutor] Stderr: {result.stderr[:200]}")
+                print(f"[CodeExecutor] Stderr: {result.stderr[:200]}")
                 output += f"\nSTDERR:\n{result.stderr}"
 
             if not result.success:
@@ -223,18 +223,18 @@ class ModalSandboxExecutor(CodeExecutor):
                     error_msg = f"Execution timed out after {self._timeout}s"
                 else:
                     error_msg = "Unknown error"
-                print(f"[ModalSandboxExecutor] Error: {error_msg}")
+                print(f"[CodeExecutor] Error: {error_msg}")
                 output += f"\nERROR: {error_msg}"
 
             if not output.strip():
-                output = "[ModalSandboxExecutor] Code executed but produced no output"
-                print("[ModalSandboxExecutor] Warning: No output produced")
+                output = "[CodeExecutor] Code executed but produced no output"
+                print("[CodeExecutor] Warning: No output produced")
 
             # Store rich output data dicts for image analysis
             self._last_rich_outputs = [ro.data for ro in result.rich_outputs]
 
             if self._last_rich_outputs:
-                print(f"[ModalSandboxExecutor] Found {len(self._last_rich_outputs)} rich outputs")
+                print(f"[CodeExecutor] Found {len(self._last_rich_outputs)} rich outputs")
 
             if self._last_rich_outputs:
                 image_analyses = []
@@ -260,8 +260,8 @@ class ModalSandboxExecutor(CodeExecutor):
             import traceback
 
             error_details = traceback.format_exc()
-            print(f"[ModalSandboxExecutor] Exception occurred: {str(e)}")
-            print(f"[ModalSandboxExecutor] Traceback:\n{error_details}")
+            print(f"[CodeExecutor] Exception occurred: {str(e)}")
+            print(f"[CodeExecutor] Traceback:\n{error_details}")
             return CodeResult(
                 exit_code=1, output=f"Execution failed: {str(e)}\n\nTraceback:\n{error_details}"
             )

--- a/packages/autodiscovery/src/autodiscovery/agents.py
+++ b/packages/autodiscovery/src/autodiscovery/agents.py
@@ -496,6 +496,22 @@ class CodeBlockWrapperTransform(transforms.MessageTransform):
         return "CodeBlockWrapperTransform", True
 
 
+def code_transform_working_dir(
+    backend: str, work_dir: str, modal_working_dir: str | None
+) -> str:
+    """Return the directory the code transform should ``os.chdir`` into per cell.
+
+    For the process/local backends this must be **absolute**: their subprocess
+    already starts with ``cwd=work_dir``, so a relative path injected by
+    :class:`SimpleCodeBlockTransform` would stack (``work_dir/work_dir``) and
+    raise ``FileNotFoundError``. modal uses its absolute mount path (``/data``),
+    which is idempotent regardless of the sandbox's starting directory.
+    """
+    if backend == "modal":
+        return modal_working_dir
+    return os.path.abspath(work_dir)
+
+
 class SimpleCodeBlockTransform(transforms.MessageTransform):
     """Simple transform that extracts code from JSON and wraps it in markdown code blocks."""
 
@@ -867,14 +883,8 @@ def install(package):
     if backend in ("modal", "process"):
         # For sandbox-style backends, use simple transform without image analysis patch
         # (the executor handles image analysis internally)
-        # Pass the working_dir so code can change to that directory. Use an
-        # absolute path for the process backend: its subprocess already runs with
-        # cwd=work_dir, so a relative os.chdir(work_dir) injected by the transform
-        # would stack (work_dir/work_dir) and fail. modal uses the absolute mount
-        # path (/data), which is already idempotent.
-        sandbox_working_dir = (
-            modal_working_dir if backend == "modal" else os.path.abspath(work_dir)
-        )
+        # Pass the working_dir so code can change to that directory.
+        sandbox_working_dir = code_transform_working_dir(backend, work_dir, modal_working_dir)
         transform_messages_capability = transform_messages.TransformMessages(
             transforms=[SimpleCodeBlockTransform(working_dir=sandbox_working_dir)]
         )

--- a/packages/autodiscovery/src/autodiscovery/agents.py
+++ b/packages/autodiscovery/src/autodiscovery/agents.py
@@ -867,8 +867,14 @@ def install(package):
     if backend in ("modal", "process"):
         # For sandbox-style backends, use simple transform without image analysis patch
         # (the executor handles image analysis internally)
-        # Pass the working_dir so code can change to that directory
-        sandbox_working_dir = modal_working_dir if backend == "modal" else work_dir
+        # Pass the working_dir so code can change to that directory. Use an
+        # absolute path for the process backend: its subprocess already runs with
+        # cwd=work_dir, so a relative os.chdir(work_dir) injected by the transform
+        # would stack (work_dir/work_dir) and fail. modal uses the absolute mount
+        # path (/data), which is already idempotent.
+        sandbox_working_dir = (
+            modal_working_dir if backend == "modal" else os.path.abspath(work_dir)
+        )
         transform_messages_capability = transform_messages.TransformMessages(
             transforms=[SimpleCodeBlockTransform(working_dir=sandbox_working_dir)]
         )

--- a/packages/autodiscovery/src/autodiscovery/dataset.py
+++ b/packages/autodiscovery/src/autodiscovery/dataset.py
@@ -159,6 +159,24 @@ def get_asta_description(dataset_metadata_path: str) -> str:
     return "\n".join(description)
 
 
+def resolve_local_dataset_source(dataset_fpath: str) -> str:
+    """Resolve a dataset path to an existing local file.
+
+    ``get_datasets_fpaths`` resolves dataset names relative to the metadata
+    file's directory, but the webstack stores uploads in a ``data/`` subdirectory
+    alongside ``metadata.json`` (the same convention modal's ``bucket_path``
+    uses). When the metadata-relative path does not exist, fall back to that
+    ``data/`` copy so process/local backends symlink the real file rather than a
+    dangling path. Returns the absolute path (original if no ``data/`` copy).
+    """
+    abs_src = os.path.abspath(dataset_fpath)
+    if not os.path.exists(abs_src):
+        alt_src = os.path.join(os.path.dirname(abs_src), "data", os.path.basename(abs_src))
+        if os.path.exists(alt_src):
+            return alt_src
+    return abs_src
+
+
 def get_datasets_fpaths(dataset_metadata: str, is_blade=False) -> (list, str):
     is_s3 = dataset_metadata.startswith("s3")
     _dataset_metadata = dataset_metadata

--- a/packages/autodiscovery/src/autodiscovery/run.py
+++ b/packages/autodiscovery/src/autodiscovery/run.py
@@ -12,7 +12,11 @@ from time import time
 from autodiscovery.agents import get_agents
 from autodiscovery.args import ArgParser
 from autodiscovery.beliefs import calculate_prior_and_posterior_beliefs
-from autodiscovery.dataset import get_datasets_fpaths, get_load_dataset_experiment
+from autodiscovery.dataset import (
+    get_datasets_fpaths,
+    get_load_dataset_experiment,
+    resolve_local_dataset_source,
+)
 from autodiscovery.future_utils import gather_completed_futures
 from autodiscovery.llm_retry import apply_openai_wrapper_usage_tracking
 from autodiscovery.llm_usage import (
@@ -419,19 +423,8 @@ def run_mcts(
         # We symlink anything that isn't already under work_dir.
         if backend != "modal":
             for dataset_fpath in dataset_paths:
-                abs_src = os.path.abspath(dataset_fpath)
-                # get_datasets_fpaths resolves dataset names relative to the
-                # metadata file's directory, but the webstack stores uploads in a
-                # `data/` subdirectory alongside metadata.json (the same convention
-                # modal's bucket_path uses). When the direct path is absent, fall
-                # back to that data/ copy so we symlink the real file rather than a
-                # dangling path.
-                if not os.path.exists(abs_src):
-                    alt_src = os.path.join(
-                        os.path.dirname(abs_src), "data", os.path.basename(abs_src)
-                    )
-                    if os.path.exists(alt_src):
-                        abs_src = alt_src
+                # Resolve to the real file (handles the webstack's data/ layout).
+                abs_src = resolve_local_dataset_source(dataset_fpath)
                 # Skip if already inside work_dir (e.g. easy.py already symlinked)
                 if abs_src.startswith(os.path.abspath(work_dir) + os.sep):
                     continue

--- a/packages/autodiscovery/src/autodiscovery/run.py
+++ b/packages/autodiscovery/src/autodiscovery/run.py
@@ -420,11 +420,23 @@ def run_mcts(
         if backend != "modal":
             for dataset_fpath in dataset_paths:
                 abs_src = os.path.abspath(dataset_fpath)
+                # get_datasets_fpaths resolves dataset names relative to the
+                # metadata file's directory, but the webstack stores uploads in a
+                # `data/` subdirectory alongside metadata.json (the same convention
+                # modal's bucket_path uses). When the direct path is absent, fall
+                # back to that data/ copy so we symlink the real file rather than a
+                # dangling path.
+                if not os.path.exists(abs_src):
+                    alt_src = os.path.join(
+                        os.path.dirname(abs_src), "data", os.path.basename(abs_src)
+                    )
+                    if os.path.exists(alt_src):
+                        abs_src = alt_src
                 # Skip if already inside work_dir (e.g. easy.py already symlinked)
                 if abs_src.startswith(os.path.abspath(work_dir) + os.sep):
                     continue
                 dst = os.path.join(work_dir, os.path.basename(dataset_fpath))
-                if not os.path.exists(dst):
+                if not os.path.lexists(dst):
                     os.symlink(abs_src, dst)
 
         base_agent_objs = None

--- a/packages/autodiscovery/tests/test_agents_paths.py
+++ b/packages/autodiscovery/tests/test_agents_paths.py
@@ -1,0 +1,54 @@
+"""Tests for the code-execution working-dir handling in agents.py.
+
+Guards the process/local vs modal path translation: the code transform injects
+`os.chdir(working_dir)` into every cell, and the process/local subprocess
+already starts with cwd=work_dir, so that injected path must be absolute or it
+stacks (work_dir/work_dir) and fails with FileNotFoundError.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from autodiscovery.agents import SimpleCodeBlockTransform, code_transform_working_dir
+
+
+def test_working_dir_modal_uses_mount_path() -> None:
+    assert code_transform_working_dir("modal", "work", "/data") == "/data"
+
+
+def test_working_dir_process_is_absolute() -> None:
+    result = code_transform_working_dir("process", "work", None)
+    assert os.path.isabs(result)
+    assert result == os.path.abspath("work")
+
+
+def test_working_dir_local_is_absolute() -> None:
+    result = code_transform_working_dir("local", "some/rel/work", None)
+    assert os.path.isabs(result)
+    assert result == os.path.abspath("some/rel/work")
+
+
+def test_transform_injects_absolute_chdir() -> None:
+    transform = SimpleCodeBlockTransform(working_dir="/app/work")
+    messages = [{"content": json.dumps({"code": "x = 1\nprint(x)"})}]
+
+    out = transform.apply_transform(messages)
+    content = out[-1]["content"]
+
+    assert "os.chdir('/app/work')" in content
+    # The user code is preserved after the injected chdir.
+    assert "print(x)" in content
+    assert content.index("os.chdir(") < content.index("print(x)")
+
+
+def test_transform_and_working_dir_compose_to_absolute() -> None:
+    # End-to-end of the fix: process backend -> absolute dir -> absolute chdir,
+    # so it never stacks relative to the subprocess's own cwd.
+    working_dir = code_transform_working_dir("process", "work", None)
+    transform = SimpleCodeBlockTransform(working_dir=working_dir)
+    content = transform.apply_transform([{"content": json.dumps({"code": "pass"})}])[-1][
+        "content"
+    ]
+    assert f"os.chdir('{os.path.abspath('work')}')" in content

--- a/packages/autodiscovery/tests/test_dataset_paths.py
+++ b/packages/autodiscovery/tests/test_dataset_paths.py
@@ -1,0 +1,52 @@
+"""Tests for local dataset path resolution across the job/subprocess boundary.
+
+These guard the webstack's `data/` upload layout: `get_datasets_fpaths` resolves
+dataset names relative to the metadata file's directory, but the actual files
+live in a sibling `data/` directory (matching modal's `bucket_path`). The
+process/local backends symlink the resolved path into work_dir, so a wrong
+resolution produces a dangling symlink (`ls` shows it, `open()` fails).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autodiscovery.dataset import resolve_local_dataset_source
+
+
+def test_resolves_direct_path_when_present(tmp_path: Path) -> None:
+    # Colocated layout (CLI): metadata dir contains the file directly.
+    f = tmp_path / "data.csv"
+    f.write_text("a,b\n1,2\n")
+    assert resolve_local_dataset_source(str(f)) == str(f)
+
+
+def test_falls_back_to_data_subdir(tmp_path: Path) -> None:
+    # Webstack layout: metadata dir has a `data/` subdir holding the real file.
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    real = data_dir / "seattle.csv"
+    real.write_text("a,b\n1,2\n")
+
+    # The path get_datasets_fpaths would build (metadata-dir relative, no data/).
+    resolved = resolve_local_dataset_source(str(tmp_path / "seattle.csv"))
+
+    assert resolved == str(real)
+    # And it points at a file that actually exists (no dangling symlink).
+    assert Path(resolved).is_file()
+
+
+def test_returns_absolute_original_when_neither_exists(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.csv"
+    resolved = resolve_local_dataset_source(str(missing))
+    assert resolved == str(missing.resolve()) or resolved == str(missing)
+    assert Path(resolved).is_absolute()
+
+
+def test_prefers_direct_path_over_data_subdir(tmp_path: Path) -> None:
+    # If both exist, the direct (metadata-relative) file wins — no surprise remap.
+    direct = tmp_path / "x.csv"
+    direct.write_text("1")
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "x.csv").write_text("2")
+    assert resolve_local_dataset_source(str(direct)) == str(direct)

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/base.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/base.py
@@ -18,6 +18,11 @@ from typing import Any
 from ..config import JobConfig
 from ..exceptions import JobBackendError
 
+# Code-execution backends the AD job understands (its --backend choices). "modal"
+# runs code in a remote Modal sandbox with a scoped, read-only per-job data mount;
+# "process"/"local" run it inside the job container (subprocess / in-process).
+_CODE_EXECUTION_BACKENDS = ("process", "local", "modal")
+
 
 def build_job_args(
     userid: str,
@@ -64,16 +69,23 @@ def build_job_args(
         The list of CLI arguments for ``python -m autodiscovery.run``.
 
     Raises:
-        JobBackendError: If ``n_experiments`` is not provided.
+        JobBackendError: If ``n_experiments`` is not provided, or the configured
+            code-execution backend is not one of ``process``/``local``/``modal``.
     """
     if n_experiments is None:
         raise JobBackendError("n_experiments is required to run a job")
+
+    code_backend = config.code_execution_backend
+    if code_backend not in _CODE_EXECUTION_BACKENDS:
+        raise JobBackendError(
+            f"Unknown code_execution_backend {code_backend!r}; "
+            f"expected one of {', '.join(_CODE_EXECUTION_BACKENDS)}"
+        )
 
     # Construct paths
     job_base = f"users/{userid}/jobs/{jobid}"
     metadata_path = f"/mnt/gcs/{job_base}/metadata.json"
     output_path = f"/mnt/gcs/{job_base}/output"
-    bucket_path = f"gs://{config.bucket}/{job_base}/data"
 
     # Build arguments - required ones first
     args = [
@@ -81,10 +93,15 @@ def build_job_args(
         f"--out_dir={output_path}",
         f"--n_experiments={n_experiments}",
         "--work_dir=work",
-        "--use_modal_sandbox",
-        f"--bucket_path={bucket_path}",
+        f"--backend={code_backend}",
         "--no-timestamp_dir",
     ]
+
+    # --bucket_path is only consumed by the modal sandbox (it mounts gs://.../data
+    # read-only as the code-execution data source). The process/local backends read
+    # the dataset straight from the /mnt/gcs job mount, so it is omitted for them.
+    if code_backend == "modal":
+        args.append(f"--bucket_path=gs://{config.bucket}/{job_base}/data")
 
     # Add optional explicit parameters if provided
     if belief_model is not None:

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/docker.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/docker.py
@@ -88,6 +88,12 @@ class DockerBackend(JobBackend):
         }
         environment["GCSFUSE_BUCKET"] = self.config.bucket
         environment["GOOGLE_APPLICATION_CREDENTIALS"] = _CONTAINER_GCP_KEY_PATH
+        # Scope the gcsfuse mount to this job's own prefix (mounted at the same
+        # deep path build_job_args expects, so the args are unchanged) rather than
+        # the whole bucket. This keeps other users' data out of the container even
+        # when code runs in-process (CODE_EXECUTION_BACKEND=process/local). Unlike
+        # Cloud Run's fixed job-level mount, the Docker backend can scope per run.
+        environment["GCSFUSE_ONLY_DIR"] = f"users/{userid}/jobs/{jobid}"
 
         # Bind-mount the GCP credentials file so gcsfuse (and google-cloud
         # clients) can authenticate. In docker-out-of-docker the bind source

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/config.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/config.py
@@ -30,6 +30,14 @@ class JobConfig:
     # AD job image reference used by the Docker backend (ignored for gcp)
     job_image: str | None = None
 
+    # Code-execution backend the AD job uses for LLM-generated code, forwarded to
+    # the job's --backend flag. "process" (default): isolated subprocess inside the
+    # job container (no cloud dependency); "local": in-process, no isolation;
+    # "modal": remote Modal sandbox with a scoped, read-only per-job data mount.
+    # See docs/configuration.md for the safe-combination matrix (this interacts with
+    # the job backend and auth/tenancy — untrusted code runs where the data is mounted).
+    code_execution_backend: str = "process"
+
     # Modal Configuration (for sandbox execution)
     modal_app_name: str = "asta-autodiscovery"
     modal_bucket_secret: str = "example-bucket-secret"
@@ -55,6 +63,9 @@ class JobConfig:
             job_name=os.environ.get("CLOUDRUN_JOB_NAME", cls.job_name),
             backend=os.environ.get("JOB_BACKEND", cls.backend),
             job_image=os.environ.get("AUTODISCOVERY_IMAGE"),
+            code_execution_backend=os.environ.get(
+                "CODE_EXECUTION_BACKEND", cls.code_execution_backend
+            ),
             modal_app_name=os.environ.get("MODAL_APP_NAME", cls.modal_app_name),
             modal_bucket_secret=os.environ.get("MODAL_BUCKET_SECRET", cls.modal_bucket_secret),
         )

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/manager.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/manager.py
@@ -1,6 +1,7 @@
 """High-level interface for managing Cloud Run jobs."""
 
 import logging
+import os
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,6 +14,33 @@ from .exceptions import DatasetExpiredError
 from .run_details import RunDetails, create_run_details, get_run_details
 
 logger = logging.getLogger(__name__)
+
+
+def _warn_if_unsafe_code_execution(config: JobConfig) -> None:
+    """Warn when in-process code execution would expose other users' data.
+
+    In-process backends (``process``/``local``) run untrusted, LLM-generated code
+    inside the job container, so that code sees whatever GCS data the container
+    mounts. The Docker backend scopes its mount to the job's own prefix, but Cloud
+    Run mounts the whole bucket (its mount is fixed per job, not per execution). So
+    ``gcp`` + in-process + a multi-user auth provider is a cross-tenant exposure:
+    steer such deployments to ``CODE_EXECUTION_BACKEND=modal`` (scoped, read-only).
+
+    This is a loud warning rather than a hard failure; when the configuration
+    syntax gains cross-field validation (issue #54) it can become a real
+    constraint. Single-user local mode (AUTH_PROVIDER=none) is unaffected.
+    """
+    multi_user = os.environ.get("AUTH_PROVIDER", "none").lower() != "none"
+    in_process = config.code_execution_backend in ("process", "local")
+    if config.backend == "gcp" and in_process and multi_user:
+        logger.warning(
+            "UNSAFE CONFIG: JOB_BACKEND=gcp with CODE_EXECUTION_BACKEND=%s runs "
+            "untrusted code in a container that mounts the entire bucket, and Cloud "
+            "Run cannot scope the mount per run. In a multi-user deployment this "
+            "exposes every user's data to executed code. Set CODE_EXECUTION_BACKEND=modal "
+            "for a scoped, read-only per-job data mount. See docs/configuration.md.",
+            config.code_execution_backend,
+        )
 
 
 @dataclass
@@ -47,6 +75,7 @@ class JobManager:
             config: Configuration (uses default from environment if None)
         """
         self.config = config or JobConfig.from_env()
+        _warn_if_unsafe_code_execution(self.config)
         self.backend = get_backend(self.config)
 
     # User operations

--- a/packages/autodiscovery_jobs/tests/test_backends.py
+++ b/packages/autodiscovery_jobs/tests/test_backends.py
@@ -45,15 +45,38 @@ def test_get_backend_unknown():
 
 
 def test_build_job_args_required(mock_config):
+    # mock_config leaves code_execution_backend at its default ("process").
     args = build_job_args("testuser", "job1", mock_config, n_experiments=4, model="gpt-4o")
 
     assert "--dataset_metadata=/mnt/gcs/users/testuser/jobs/job1/metadata.json" in args
     assert "--out_dir=/mnt/gcs/users/testuser/jobs/job1/output" in args
-    assert "--bucket_path=gs://test-bucket/users/testuser/jobs/job1/data" in args
     assert "--n_experiments=4" in args
-    assert "--use_modal_sandbox" in args
+    assert "--backend=process" in args
     assert "--no-timestamp_dir" in args
     assert "--model=gpt-4o" in args
+    # bucket_path / modal flag are modal-only
+    assert not any(a.startswith("--bucket_path=") for a in args)
+
+
+@pytest.mark.parametrize(
+    "code_backend,expects_bucket_path",
+    [("process", False), ("local", False), ("modal", True)],
+)
+def test_build_job_args_code_execution_backend(code_backend, expects_bucket_path):
+    config = JobConfig(bucket="test-bucket", code_execution_backend=code_backend)
+    args = build_job_args("u", "j", config, n_experiments=1)
+
+    assert f"--backend={code_backend}" in args
+    has_bucket_path = any(a.startswith("--bucket_path=") for a in args)
+    assert has_bucket_path is expects_bucket_path
+    if expects_bucket_path:
+        assert "--bucket_path=gs://test-bucket/users/u/jobs/j/data" in args
+
+
+def test_build_job_args_rejects_unknown_code_backend():
+    config = JobConfig(bucket="b", code_execution_backend="wasm")
+    with pytest.raises(JobBackendError):
+        build_job_args("u", "j", config, n_experiments=1)
 
 
 def test_build_job_args_requires_n_experiments(mock_config):
@@ -102,6 +125,8 @@ def test_docker_run_job_launches_container(docker_config, monkeypatch):
     assert "--model=gpt-4o" in kwargs["command"]
     # gcsfuse trigger + credentials forwarded
     assert kwargs["environment"]["GCSFUSE_BUCKET"] == "test-bucket"
+    # mount is scoped to this job's own prefix (keeps other users' data out)
+    assert kwargs["environment"]["GCSFUSE_ONLY_DIR"] == "users/testuser/jobs/job1"
     assert kwargs["environment"]["OPENAI_API_KEY"] == "sk-test"
     assert kwargs["environment"]["MODAL_TOKEN_ID"] == "tok"
     assert kwargs["environment"]["GOOGLE_APPLICATION_CREDENTIALS"] == "/secrets/gcp-key.json"

--- a/packages/autodiscovery_jobs/tests/test_manager.py
+++ b/packages/autodiscovery_jobs/tests/test_manager.py
@@ -20,6 +20,38 @@ def test_manager_default_config():
     manager = JobManager()
     assert manager.config is not None
     assert manager.config.bucket == "autodiscovery"
+    # Low-barrier default: in-process code execution, no cloud dependency.
+    assert manager.config.code_execution_backend == "process"
+
+
+@pytest.mark.parametrize(
+    "backend,code_backend,auth_provider,expect_warning",
+    [
+        # Unsafe: Cloud Run can't scope its mount, in-process code, multi-user.
+        ("gcp", "process", "password_file", True),
+        ("gcp", "local", "auth0", True),
+        # Safe: docker scopes the mount per job.
+        ("docker", "process", "password_file", False),
+        # Safe: modal mounts only the per-job data.
+        ("gcp", "modal", "password_file", False),
+        # Safe: single-user (no multi-tenant exposure).
+        ("gcp", "process", "none", False),
+    ],
+)
+def test_unsafe_code_execution_warning(
+    backend, code_backend, auth_provider, expect_warning, monkeypatch, caplog
+):
+    from autodiscovery_jobs.config import JobConfig
+
+    monkeypatch.setenv("AUTH_PROVIDER", auth_provider)
+    config = JobConfig(backend=backend, code_execution_backend=code_backend)
+    with (
+        patch("autodiscovery_jobs.manager.get_backend"),
+        caplog.at_level("WARNING", logger="autodiscovery_jobs.manager"),
+    ):
+        JobManager(config)
+    warned = any("UNSAFE CONFIG" in r.message for r in caplog.records)
+    assert warned is expect_warning
 
 
 def test_get_user_path(mock_config):


### PR DESCRIPTION
Part of #34. Makes the AutoDiscovery job's code-execution sandbox configurable, so the low-barrier default no longer depends on a specific cloud vendor.

## What

The AD job already accepts `--backend {local,process,modal}`; the webstack just hardcoded `modal`. This surfaces that knob as `CODE_EXECUTION_BACKEND`, mirroring the `JOB_BACKEND` pattern, and defaults to **`process`** — an isolated subprocess inside the job container with no cloud dependency.

- `JobConfig.code_execution_backend` (env `CODE_EXECUTION_BACKEND`).
- `build_job_args` emits `--backend=<value>`; `--bucket_path` only for `modal` (it's the modal data mount).
- Docker backend **scopes the per-job gcsfuse mount** to `users/<uid>/jobs/<jid>` (`GCSFUSE_ONLY_DIR`), mounted at the same deep path so the args stay backend-agnostic.
- Entrypoint honors `GCSFUSE_ONLY_DIR` (whole-bucket fallback otherwise).
- Loud startup warning for the one unsafe combination (below).
- Docs: safe-combination matrix; `MODAL_*` now required only when `CODE_EXECUTION_BACKEND=modal`.

## The security angle (data scoping)

In-process backends (`process`/`local`) run untrusted, generated code **inside the job container**, so it sees whatever GCS data the container mounts. The sandbox's real value is *scoping* the data view, not just isolating the process.

| Job backend | Code backend | Single user | Multi-user |
| --- | --- | --- | --- |
| `docker` | `process`/`local` | ✅ | ✅ mount scoped to the job's own prefix |
| `gcp` | `process`/`local` | ✅ | ⚠️ **unsafe** — Cloud Run mounts the whole bucket, can't scope per execution |
| `docker`/`gcp` | `modal` | ✅ | ✅ scoped, read-only per-job mount |

The docker backend self-mounts per container, so it *can* scope per run; Cloud Run's mount is fixed per job, so it can't. Multi-user Cloud Run deployments must use `modal`; the API warns loudly if misconfigured.

## Testing

`autodiscovery_jobs` suite green (77 passed), including new coverage for the arg branching, the scoped mount env, and the unsafe-combo warning matrix.

## Follow-ups
- #55 — unify `process`/`local` onto the asta-sandbox backend registry.
- #54 — cross-field config validation could turn the soft warning into a hard constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
