### PR TITLE
Add headless local runtime backend

### DIFF
--- a/api/runs/models.py
+++ b/api/runs/models.py
@@ -176,6 +176,16 @@ class MetadataModel(BaseModel):
     evidence_weight: float | None = Field(None, description="Weight for evidence in belief updates")
     warmstart_experiments: str | None = Field(None, description="Path to warmstart experiments")
     n_warmstart: int | None = Field(None, description="Number of warmstart experiments")
+    llm_provider: str | None = Field(None, description="Provider used for agent model requests")
+    embedding_provider: str | None = Field(None, description="Provider used for embeddings")
+    model: str | None = Field(None, description="Primary agent model")
+    belief_model: str | None = Field(None, description="Model used for belief sampling")
+    vision_model: str | None = Field(None, description="Model used for vision requests")
+    embedding_model: str | None = Field(None, description="Embedding model")
+    embedding_dimensions: int | None = Field(None, description="Embedding vector dimensions")
+    model_pricing: dict[str, dict[str, float]] | None = Field(
+        None, description="Per-model token pricing used for local cost estimates"
+    )
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> MetadataModel:
@@ -217,6 +227,14 @@ class MetadataModel(BaseModel):
             evidence_weight=data.get("evidence_weight"),
             warmstart_experiments=data.get("warmstart_experiments"),
             n_warmstart=data.get("n_warmstart"),
+            llm_provider=data.get("llm_provider"),
+            embedding_provider=data.get("embedding_provider"),
+            model=data.get("model"),
+            belief_model=data.get("belief_model"),
+            vision_model=data.get("vision_model"),
+            embedding_model=data.get("embedding_model"),
+            embedding_dimensions=data.get("embedding_dimensions"),
+            model_pricing=data.get("model_pricing"),
         )
 
     def to_storage_dict(self) -> dict[str, Any]:

--- a/api/runs/runs_api.py
+++ b/api/runs/runs_api.py
@@ -431,6 +431,8 @@ def create() -> Blueprint:
         )
 
         job_manager = get_job_manager()
+        if job_manager.config.backend == "local" and req.userid in PUBLIC_USERS:
+            return jsonify(GetViewerRunsResponseModel(runs=[]).model_dump()), 200
         run_ids = job_manager.list_jobs(req.userid)
 
         # TODO the order at this point is meaningless (UUID-sorted) so truncating before
@@ -573,12 +575,19 @@ def create() -> Blueprint:
                 current_app.logger.error(f"Failed to refresh run status for {req.runid}: {e}")
                 run_details = get_run_details(req.userid, req.runid)
 
-            # Get job stats
-            try:
-                job_stats = get_job_stats(userid=req.userid, jobid=req.runid, config=manager.config)
-            except Exception as e:
-                current_app.logger.error(f"Failed to get job stats for {req.runid}: {e}")
+            # Drafts have no output, and the hosted stats helper would otherwise query GCS.
+            if manager.config.backend == "local" and not (
+                run_details and run_details.execution_id
+            ):
                 job_stats = None
+            else:
+                try:
+                    job_stats = get_job_stats(
+                        userid=req.userid, jobid=req.runid, config=manager.config
+                    )
+                except Exception as e:
+                    current_app.logger.error(f"Failed to get job stats for {req.runid}: {e}")
+                    job_stats = None
 
             # Get metadata
             try:
@@ -961,6 +970,27 @@ def create() -> Blueprint:
             if not metadata:
                 raise BadRequest("Run metadata not found. Please save run configuration first.")
 
+            if manager.config.backend == "local":
+                if metadata.get("llm_provider") != "copilot":
+                    raise BadRequest(
+                        "Local runs require GitHub Copilot. Choose a Copilot model in the run settings."
+                    )
+                from autodiscovery.copilot import doctor
+
+                diagnostic = doctor()
+                if diagnostic["status"] != "ready":
+                    raise BadRequest(
+                        diagnostic.get("remediation")
+                        or "GitHub Copilot is not ready. Complete sign-in in Settings."
+                    )
+                available_models = {
+                    model["id"] for model in diagnostic["models"] if model.get("id")
+                }
+                if metadata.get("model") not in available_models:
+                    raise BadRequest(
+                        "Choose an available GitHub Copilot model in the run settings before starting."
+                    )
+
             datasets = metadata.get("datasets", [])
             for ds in datasets:
                 # If the dataset has a URL, it's an S3 preloaded file
@@ -1006,6 +1036,13 @@ def create() -> Blueprint:
             # Add optional parameters if present in metadata
             # Filter out None and empty strings, but allow 0 and other valid values
             optional_params = [
+                "model",
+                "belief_model",
+                "vision_model",
+                "llm_provider",
+                "embedding_provider",
+                "embedding_model",
+                "embedding_dimensions",
                 "exploration_weight",
                 "mcts_selection",
                 "surprisal_width",
@@ -1062,6 +1099,9 @@ def create() -> Blueprint:
             return jsonify(
                 {"error": e.message, "requested": e.requested, "available": e.available}
             ), 402  # Payment Required
+
+        except BadRequest as e:
+            return jsonify({"error": e.description}), 400
 
         except Exception as e:
             current_app.logger.error(f"Failed to submit run: {e}")

--- a/api/runs/runs_api.py
+++ b/api/runs/runs_api.py
@@ -166,6 +166,19 @@ def create() -> Blueprint:
         config = JobConfig.from_env()
         return JobManager(config)
 
+    @api.route("/runtime-config", methods=["GET"])
+    def runtime_config():
+        """Return credential-free deployment capabilities used by local clients."""
+        config = JobConfig.from_env()
+        is_local = config.backend == "local"
+        return jsonify(
+            {
+                "deployment_mode": "local" if is_local else "hosted",
+                "upload_transport": "api" if is_local else "presigned",
+                "hosted_features": not is_local,
+            }
+        )
+
     @api.route("/create", methods=["POST"])
     @requires_auth(check_permissions=[PermissionType.HIGHER_UPLOAD_LIMIT])
     def create_run():
@@ -192,7 +205,7 @@ def create() -> Blueprint:
             path = manager.create_job(userid, runid)
 
             # Create run_details.json
-            run_details = create_run_details(userid, runid)
+            run_details = create_run_details(userid, runid, manager.config)
 
             # Check if user has HIGHER_UPLOAD_LIMIT permission and return the actual limit
             has_higher_upload_limit = getattr(request, PermissionType.HIGHER_UPLOAD_LIMIT.value, False)
@@ -951,7 +964,11 @@ def create() -> Blueprint:
             datasets = metadata.get("datasets", [])
             for ds in datasets:
                 # If the dataset has a URL, it's an S3 preloaded file
-                if ds.get("url") and ds.get("url").startswith("gs://"):
+                if (
+                    manager.config.backend != "local"
+                    and ds.get("url")
+                    and ds.get("url").startswith("gs://")
+                ):
                     if not has_ai1_permission:
                         return jsonify({"error": "Permission denied for preloaded datasets"}), 403
                     filename = ds.get("name")
@@ -975,9 +992,10 @@ def create() -> Blueprint:
                 raise BadRequest("Number of Experiments is required in metadata")
 
             # Validate experiment count and sufficient credits before submission
-            check_experiment_limits(
-                n_experiments=n_experiments, userid=req.userid, config=manager.config
-            )
+            if manager.config.backend != "local":
+                check_experiment_limits(
+                    n_experiments=n_experiments, userid=req.userid, config=manager.config
+                )
 
             # Build job parameters from metadata
             job_params = {
@@ -1015,10 +1033,11 @@ def create() -> Blueprint:
                     "status_checked_at": datetime.now(UTC).isoformat(),
                     "origin_url": origin_url,
                 },
+                manager.config,
             )
 
             # Get updated run_details to return to frontend
-            run_details = get_run_details(req.userid, req.runid)
+            run_details = get_run_details(req.userid, req.runid, manager.config)
             if not run_details:
                 return jsonify({"error": "Failed to retrieve run details after submission"}), 500
 

--- a/api/tests/test_local_runtime.py
+++ b/api/tests/test_local_runtime.py
@@ -1,0 +1,72 @@
+"""Tests for provider-neutral headless local runtime behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autodiscovery_jobs import JobConfig, JobManager
+from flask import Flask
+from runs import runs_api
+from utils.experiments import ExperimentTree
+
+
+def test_runtime_config_selects_local_api_upload(monkeypatch) -> None:
+    monkeypatch.setenv("JOB_BACKEND", "local")
+    app = Flask(__name__)
+    app.register_blueprint(runs_api.create(), url_prefix="/api/runs")
+
+    response = app.test_client().get("/api/runs/runtime-config")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "deployment_mode": "local",
+        "upload_transport": "api",
+        "hosted_features": False,
+    }
+
+
+def test_runtime_config_preserves_hosted_default(monkeypatch) -> None:
+    monkeypatch.delenv("JOB_BACKEND", raising=False)
+    app = Flask(__name__)
+    app.register_blueprint(runs_api.create(), url_prefix="/api/runs")
+
+    response = app.test_client().get("/api/runs/runtime-config")
+
+    assert response.get_json() == {
+        "deployment_mode": "hosted",
+        "upload_transport": "presigned",
+        "hosted_features": True,
+    }
+
+
+def test_local_manager_crud_avoids_gcs(tmp_path: Path) -> None:
+    manager = JobManager(JobConfig(backend="local", local_root=str(tmp_path)))
+
+    run_path = Path(manager.create_job("local", "run-1"))
+    manager.upload_metadata("local", "run-1", {"name": "Local run"})
+
+    assert run_path == tmp_path / "runs" / "run-1"
+    assert manager.list_jobs("local") == ["run-1"]
+    assert manager.get_metadata("local", "run-1") == {"name": "Local run"}
+
+
+def test_local_experiment_tree_reads_output(tmp_path: Path) -> None:
+    config = JobConfig(backend="local", local_root=str(tmp_path))
+    manager = JobManager(config)
+    run_path = Path(manager.create_job("local", "run-1"))
+    node = {
+        "id": "node_0_1",
+        "parent_id": None,
+        "creation_idx": 1,
+        "success": True,
+        "hypothesis": "Local hypothesis",
+    }
+    (run_path / "output" / "mcts_node_0_1.json").write_text(
+        json.dumps(node), encoding="utf-8"
+    )
+
+    tree = ExperimentTree.load("local", "run-1", config)
+
+    assert len(tree) == 1
+    assert tree.get_node("node_0_1").hypothesis == "Local hypothesis"

--- a/api/user/user_api.py
+++ b/api/user/user_api.py
@@ -55,6 +55,17 @@ def create() -> Blueprint:
 
         try:
             job_manager = get_job_manager()
+            if job_manager.config.backend == "local":
+                return jsonify(
+                    {
+                        "credits": {
+                            "granted": 0,
+                            "consumed": 0,
+                            "pending": 0,
+                            "available": 0,
+                        }
+                    }
+                ), 200
             user_credits = get_user_credits(userid=user_id, config=job_manager.config)
 
             return jsonify(

--- a/api/utils/experiments.py
+++ b/api/utils/experiments.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import logging
 import threading
+from pathlib import Path
 from typing import Any
 
 from autodiscovery_jobs import JobConfig
@@ -190,13 +192,36 @@ class ExperimentTree:
         """
         config = config or JobConfig()
         filename = f"mcts_{experiment_id}.json"
-        node_data = read_experiment_node(userid, jobid, filename, config)
+        if config.backend == "local":
+            from autodiscovery_jobs.local_storage import LocalStorage
+
+            node_path = LocalStorage(config).get_job_path(userid, jobid) / "output" / filename
+            try:
+                node_data = json.loads(node_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                node_data = None
+        else:
+            node_data = read_experiment_node(userid, jobid, filename, config)
         if node_data is None:
             return None
         return ExperimentNode(node_data, filename)
 
     def _load_from_gcs(self) -> None:
         """Load all experiment nodes from GCS in parallel."""
+        if self.config.backend == "local":
+            from autodiscovery_jobs.local_storage import LocalStorage
+
+            output_path = LocalStorage(self.config).get_job_path(self.userid, self.jobid) / "output"
+            for node_path in sorted(output_path.glob("mcts_node_*.json")):
+                try:
+                    value = json.loads(node_path.read_text(encoding="utf-8"))
+                    if isinstance(value, dict):
+                        node = ExperimentNode(value, node_path.name)
+                        self._nodes[node.id] = node
+                except (OSError, ValueError, json.JSONDecodeError) as exc:
+                    logging.warning("Failed to parse local experiment node %s: %s", node_path, exc)
+            self._build_tree_relationships()
+            return
         try:
             filenames = list_experiment_files(self.userid, self.jobid, self.config)
         except Exception as e:

--- a/packages/autodiscovery/src/autodiscovery/local_worker.py
+++ b/packages/autodiscovery/src/autodiscovery/local_worker.py
@@ -1,0 +1,55 @@
+"""Local worker entry point that runs AutoDiscovery and emits its HTML report."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from collections.abc import Sequence
+from contextlib import suppress
+from pathlib import Path
+
+from .args import ArgParser
+from .copilot_provider import close_copilot_runtime
+from .report import generate_report
+from .run import main as run_main
+
+
+def validate_run_completion(out_dir: str, requested_experiments: int) -> None:
+    """Require the requested number of successful non-loading experiments."""
+    nodes_path = Path(out_dir) / "mcts_nodes.json"
+    if not nodes_path.is_file():
+        raise RuntimeError("AutoDiscovery did not produce aggregate node results.")
+    with nodes_path.open(encoding="utf-8") as nodes_file:
+        nodes = json.load(nodes_file)
+    if not isinstance(nodes, list):
+        raise RuntimeError("AutoDiscovery aggregate node results are invalid.")
+    successful = [
+        node
+        for node in nodes
+        if isinstance(node, dict) and node.get("hypothesis") and node.get("success") is True
+    ]
+    if len(successful) < requested_experiments:
+        raise RuntimeError(
+            "AutoDiscovery completed "
+            f"{len(successful)} of {requested_experiments} requested successful experiments. "
+            "Partial artifacts and the report were preserved."
+        )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the existing engine, generate its report, and clean its work directory."""
+    args = ArgParser().parse_args(argv)
+    try:
+        run_main(args)
+        generate_report(args.out_dir)
+        validate_run_completion(args.out_dir, args.n_experiments)
+        if args.delete_work_dir:
+            shutil.rmtree(args.work_dir, ignore_errors=True)
+    finally:
+        with suppress(Exception):
+            close_copilot_runtime()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/autodiscovery/tests/test_local_worker.py
+++ b/packages/autodiscovery/tests/test_local_worker.py
@@ -1,0 +1,74 @@
+"""Tests for the local engine/report wrapper."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from autodiscovery import local_worker
+
+
+def test_local_worker_runs_engine_and_report(monkeypatch, tmp_path: Path) -> None:
+    """Delegate to the existing engine before generating its static report."""
+    args = SimpleNamespace(
+        out_dir=str(tmp_path / "output"),
+        work_dir=str(tmp_path / "work"),
+        delete_work_dir=False,
+        n_experiments=0,
+    )
+    calls = []
+    monkeypatch.setattr(
+        local_worker,
+        "ArgParser",
+        lambda: SimpleNamespace(parse_args=lambda argv: args),
+    )
+    monkeypatch.setattr(local_worker, "run_main", lambda parsed: calls.append(("run", parsed)))
+    monkeypatch.setattr(
+        local_worker,
+        "generate_report",
+        lambda out_dir: calls.append(("report", out_dir)),
+    )
+    monkeypatch.setattr(
+        local_worker,
+        "validate_run_completion",
+        lambda out_dir, requested: calls.append(("validate", (out_dir, requested))),
+    )
+    monkeypatch.setattr(
+        local_worker,
+        "close_copilot_runtime",
+        lambda: calls.append(("close", None)),
+    )
+
+    result = local_worker.main(["--ignored"])
+
+    assert result == 0
+    assert calls == [
+        ("run", args),
+        ("report", args.out_dir),
+        ("validate", (args.out_dir, 0)),
+        ("close", None),
+    ]
+
+
+def test_completion_validation_rejects_failed_substantive_node(tmp_path: Path) -> None:
+    """Do not report process success when belief/reward marked the experiment failed."""
+    output = tmp_path / "output"
+    output.mkdir()
+    (output / "mcts_nodes.json").write_text(
+        '[{"hypothesis": null, "success": true}, {"hypothesis": "H", "success": false}]',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="0 of 1 requested"):
+        local_worker.validate_run_completion(str(output), 1)
+
+
+def test_completion_validation_accepts_requested_successes(tmp_path: Path) -> None:
+    """Accept runs that completed the requested substantive experiment budget."""
+    output = tmp_path / "output"
+    output.mkdir()
+    (output / "mcts_nodes.json").write_text(
+        '[{"hypothesis": null, "success": true}, {"hypothesis": "H", "success": true}]',
+        encoding="utf-8",
+    )
+
+    local_worker.validate_run_completion(str(output), 1)

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/__init__.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/__init__.py
@@ -37,13 +37,20 @@ def get_backend(config: JobConfig | None = None) -> JobBackend:
         from .docker import DockerBackend
 
         return DockerBackend(config)
+    if backend == "local":
+        from .local import LocalProcessBackend
 
-    raise JobBackendError(f"Unknown job backend '{config.backend}'. Expected 'gcp' or 'docker'.")
+        return LocalProcessBackend(config)
+
+    raise JobBackendError(
+        f"Unknown job backend '{config.backend}'. Expected 'gcp', 'docker', or 'local'."
+    )
 
 
 __all__ = [
     "JobBackend",
     "CloudRunBackend",
+    "LocalProcessBackend",
     "build_job_args",
     "get_backend",
 ]

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/local.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/local.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import stat
 import sys
 from pathlib import Path
@@ -54,14 +55,14 @@ class LocalProcessBackend(JobBackend):
             dataset["name"] = alias
 
         for alias, source in aliases.items():
-            if data_path in source.parents:
-                source.chmod(source.stat().st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
             destination = work_path / alias
             if destination.is_symlink() or destination.exists():
-                if destination.is_symlink() and destination.resolve() == source:
-                    continue
                 raise FileExistsError(f"Local runtime dataset alias already exists: {alias}")
-            destination.symlink_to(source)
+            shutil.copy2(source, destination)
+            destination.chmod(
+                destination.stat().st_mode
+                & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+            )
 
         runtime_metadata_path = work_path / ".autodiscovery-metadata.json"
         runtime_metadata_path.write_text(json.dumps(runtime_metadata, indent=2), encoding="utf-8")

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/local.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/local.py
@@ -1,0 +1,150 @@
+"""Local subprocess job backend for single-user AutoDiscovery deployments."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+from ..local_runner import LocalProcessRunner
+from ..local_storage import LocalStorage
+from .base import JobBackend
+
+
+class LocalProcessBackend(JobBackend):
+    """Launch AutoDiscovery workers directly as managed local subprocesses."""
+
+    def __init__(self, config) -> None:
+        """Initialize local filesystem storage and process lifecycle management."""
+        super().__init__(config)
+        self.storage = LocalStorage(config)
+        self.runner = LocalProcessRunner(config)
+
+    @staticmethod
+    def _prepare_runtime_view(
+        run_path: Path,
+        metadata: dict[str, Any],
+        source_files: dict[str, Path] | None = None,
+    ) -> Path:
+        """Expose declared datasets at stable basenames in the worker directory."""
+        data_path = (run_path / "data").resolve()
+        work_path = run_path / "work"
+        work_path.mkdir(parents=True, exist_ok=True)
+        runtime_metadata = json.loads(json.dumps(metadata))
+        source_files = source_files or {}
+        aliases: dict[str, Path] = {}
+
+        for dataset in runtime_metadata.get("datasets", []):
+            relative_name = str(dataset.get("name") or "")
+            source = source_files.get(relative_name)
+            if source is None:
+                source = (data_path / relative_name).resolve()
+                if source == data_path or data_path not in source.parents:
+                    raise ValueError(f"Dataset path escapes the local run: {relative_name}")
+            if not source.is_file() or source.is_symlink():
+                raise FileNotFoundError(f"Local dataset file not found: {relative_name}")
+            alias = source.name
+            previous = aliases.get(alias)
+            if previous is not None and previous != source:
+                raise ValueError(f"Local dataset filenames must be unique: {alias}")
+            aliases[alias] = source
+            dataset["name"] = alias
+
+        for alias, source in aliases.items():
+            if data_path in source.parents:
+                source.chmod(source.stat().st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+            destination = work_path / alias
+            if destination.is_symlink() or destination.exists():
+                if destination.is_symlink() and destination.resolve() == source:
+                    continue
+                raise FileExistsError(f"Local runtime dataset alias already exists: {alias}")
+            destination.symlink_to(source)
+
+        runtime_metadata_path = work_path / ".autodiscovery-metadata.json"
+        runtime_metadata_path.write_text(json.dumps(runtime_metadata, indent=2), encoding="utf-8")
+        return runtime_metadata_path
+
+    def run_job(
+        self,
+        userid: str,
+        jobid: str,
+        n_experiments: int | None = None,
+        model: str | None = None,
+        belief_model: str | None = None,
+        temperature: float | None = None,
+        belief_temperature: float | None = None,
+        k_experiments: int | None = None,
+        mcts_selection: str | None = None,
+        reasoning_effort: str | None = None,
+        exploration_weight: float | None = None,
+        code_timeout: int | None = None,
+        n_warmstart: int | None = None,
+        **kwargs: Any,
+    ) -> str:
+        """Launch the local worker and return its persistent execution ID."""
+        if n_experiments is None:
+            raise ValueError("n_experiments is required to run a job")
+        run_path = self.storage.get_job_path(userid, jobid)
+        metadata = self.storage.get_metadata(userid, jobid)
+        if not metadata:
+            raise FileNotFoundError(f"Run metadata not found: {jobid}")
+        runtime_metadata = self._prepare_runtime_view(
+            run_path,
+            metadata,
+            self.storage.get_dataset_source_files(userid, jobid),
+        )
+        command = [
+            sys.executable,
+            "-m",
+            "autodiscovery.local_worker",
+            f"--dataset_metadata={runtime_metadata}",
+            f"--out_dir={run_path / 'output'}",
+            f"--n_experiments={n_experiments}",
+            f"--work_dir={run_path / 'work'}",
+            f"--backend={self.config.code_execution_backend}",
+            "--no-timestamp_dir",
+        ]
+        optional_args = {
+            "model": model,
+            "belief_model": belief_model,
+            "temperature": temperature,
+            "belief_temperature": belief_temperature,
+            "k_experiments": k_experiments,
+            "mcts_selection": mcts_selection,
+            "reasoning_effort": reasoning_effort,
+            "exploration_weight": exploration_weight,
+            "code_timeout": code_timeout,
+            "n_warmstart": n_warmstart,
+            **kwargs,
+        }
+        for key, value in optional_args.items():
+            if value is None:
+                continue
+            if isinstance(value, bool):
+                command.append(f"--{key}" if value else f"--no-{key}")
+            else:
+                command.append(f"--{key}={value}")
+        return self.runner.start(
+            command,
+            run_id=jobid,
+            cwd=run_path,
+            log_path=run_path / "logs" / "engine.log",
+            env=dict(os.environ),
+        )
+
+    def get_job_status(self, execution_id: str) -> dict[str, Any]:
+        """Return the persisted status for a local execution."""
+        return self.runner.get_status(execution_id)
+
+    def cancel_job(self, execution_id: str) -> None:
+        """Terminate a local execution process group."""
+        self.runner.cancel(execution_id)
+
+    def get_job_logs(self, execution_id: str | None = None, limit: int = 50) -> list[str]:
+        """Return recent combined output for a local execution."""
+        if execution_id is None:
+            raise ValueError("Local logs require an execution ID")
+        return self.runner.get_logs(execution_id, limit)

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/config.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
 
 # How many days uploaded datasets are retained before the cleanup cron deletes
 # them from GCS.  Both the cleanup script and the API's expiry estimate read
@@ -42,6 +43,11 @@ class JobConfig:
     modal_app_name: str = "asta-autodiscovery"
     modal_bucket_secret: str = "example-bucket-secret"
 
+    # Single-user local process backend configuration (ignored by other backends).
+    local_root: str = str(Path.home() / "AutoDiscovery")
+    local_user_id: str = "local"
+    local_max_concurrent_jobs: int = 1
+
     @classmethod
     def from_env(cls, **overrides) -> JobConfig:
         """Create configuration from environment variables with optional overrides.
@@ -68,6 +74,14 @@ class JobConfig:
             ),
             modal_app_name=os.environ.get("MODAL_APP_NAME", cls.modal_app_name),
             modal_bucket_secret=os.environ.get("MODAL_BUCKET_SECRET", cls.modal_bucket_secret),
+            local_root=os.environ.get("AUTODISCOVERY_LOCAL_ROOT", cls.local_root),
+            local_user_id=os.environ.get("AUTODISCOVERY_LOCAL_USER_ID", cls.local_user_id),
+            local_max_concurrent_jobs=int(
+                os.environ.get(
+                    "AUTODISCOVERY_LOCAL_MAX_CONCURRENT_JOBS",
+                    cls.local_max_concurrent_jobs,
+                )
+            ),
         )
 
         # Apply overrides

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/local_runner.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/local_runner.py
@@ -1,0 +1,184 @@
+"""Managed subprocess execution for local AutoDiscovery runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import tempfile
+import threading
+import uuid
+from collections.abc import Sequence
+from contextlib import suppress
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .config import JobConfig
+
+
+class LocalProcessRunner:
+    """Run local jobs in isolated process groups with persistent state and logs."""
+
+    def __init__(self, config: JobConfig) -> None:
+        """Initialize the runner for a configured application data root."""
+        self.config = config
+        self.root = Path(config.local_root).expanduser().resolve()
+        self.executions_root = self.root / "executions"
+        self._processes: dict[str, subprocess.Popen[str]] = {}
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(UTC).isoformat()
+
+    def _state_path(self, execution_id: str) -> Path:
+        if not execution_id.startswith("local-") or Path(execution_id).name != execution_id:
+            raise ValueError("Invalid local execution ID")
+        return self.executions_root / f"{execution_id}.json"
+
+    def _write_state(self, state: dict[str, Any]) -> None:
+        self.executions_root.mkdir(parents=True, exist_ok=True)
+        destination = self._state_path(str(state["execution_id"]))
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=self.executions_root,
+            prefix=".execution-",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            json.dump(state, temp_file, indent=2)
+            temp_path = Path(temp_file.name)
+        temp_path.replace(destination)
+
+    def _read_state(self, execution_id: str) -> dict[str, Any]:
+        state_path = self._state_path(execution_id)
+        if not state_path.is_file():
+            raise FileNotFoundError(f"Unknown local execution: {execution_id}")
+        with state_path.open(encoding="utf-8") as state_file:
+            state = json.load(state_file)
+        if not isinstance(state, dict):
+            raise ValueError("Local execution state must be a JSON object")
+        return state
+
+    @staticmethod
+    def _pid_is_running(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    def _running_count(self) -> int:
+        if not self.executions_root.is_dir():
+            return 0
+        count = 0
+        for state_path in self.executions_root.glob("local-*.json"):
+            try:
+                with state_path.open(encoding="utf-8") as state_file:
+                    state = json.load(state_file)
+                if state.get("phase") == "RUNNING" and self._pid_is_running(int(state["pid"])):
+                    count += 1
+            except (OSError, ValueError, TypeError, json.JSONDecodeError):
+                continue
+        return count
+
+    def start(
+        self,
+        command: Sequence[str],
+        *,
+        run_id: str,
+        cwd: Path,
+        log_path: Path,
+        env: dict[str, str] | None = None,
+    ) -> str:
+        """Start one managed command and return its persistent execution ID."""
+        if not command:
+            raise ValueError("Local execution command may not be empty")
+        with self._lock:
+            if self._running_count() >= self.config.local_max_concurrent_jobs:
+                raise RuntimeError("Local job concurrency limit reached")
+            execution_id = f"local-{uuid.uuid4()}"
+            cwd.mkdir(parents=True, exist_ok=True)
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_file = log_path.open("a", encoding="utf-8")
+            try:
+                process = subprocess.Popen(
+                    list(command),
+                    cwd=cwd,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    start_new_session=True,
+                )
+            finally:
+                log_file.close()
+            state = {
+                "execution_id": execution_id,
+                "run_id": run_id,
+                "pid": process.pid,
+                "phase": "RUNNING",
+                "command": list(command),
+                "cwd": str(cwd),
+                "log_path": str(log_path),
+                "create_time": self._now(),
+                "completion_time": None,
+                "return_code": None,
+            }
+            self._processes[execution_id] = process
+            self._write_state(state)
+            threading.Thread(
+                target=self._monitor,
+                args=(execution_id, process),
+                name=f"autodiscovery-{execution_id}",
+                daemon=True,
+            ).start()
+            return execution_id
+
+    def _monitor(self, execution_id: str, process: subprocess.Popen[str]) -> None:
+        return_code = process.wait()
+        with self._lock:
+            state = self._read_state(execution_id)
+            if state.get("phase") != "CANCELLED":
+                state["phase"] = "SUCCEEDED" if return_code == 0 else "FAILED"
+            state["return_code"] = return_code
+            state["completion_time"] = self._now()
+            self._write_state(state)
+            self._processes.pop(execution_id, None)
+
+    def get_status(self, execution_id: str) -> dict[str, Any]:
+        """Return persisted status, detecting stale running processes after restart."""
+        with self._lock:
+            state = self._read_state(execution_id)
+            if state.get("phase") == "RUNNING" and not self._pid_is_running(int(state["pid"])):
+                state["phase"] = "FAILED"
+                state["completion_time"] = self._now()
+                state["error_code"] = "PROCESS_LOST"
+                self._write_state(state)
+            return dict(state)
+
+    def cancel(self, execution_id: str) -> None:
+        """Terminate an execution process group and persist cancellation."""
+        with self._lock:
+            state = self._read_state(execution_id)
+            if state.get("phase") != "RUNNING":
+                return
+            pid = int(state["pid"])
+            with suppress(ProcessLookupError):
+                os.killpg(pid, signal.SIGTERM)
+            state["phase"] = "CANCELLED"
+            state["completion_time"] = self._now()
+            self._write_state(state)
+
+    def get_logs(self, execution_id: str, limit: int = 50) -> list[str]:
+        """Return the last requested lines from a local execution log."""
+        state = self._read_state(execution_id)
+        log_path = Path(str(state["log_path"]))
+        if not log_path.is_file():
+            return []
+        return log_path.read_text(encoding="utf-8", errors="replace").splitlines()[-limit:]

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/local_storage.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/local_storage.py
@@ -1,0 +1,352 @@
+"""Filesystem storage for single-user local AutoDiscovery runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .config import JobConfig
+
+
+class LocalStorage:
+    """Store local-mode runs under a configured application data root."""
+
+    def __init__(self, config: JobConfig) -> None:
+        """Initialize storage without creating the root until it is needed."""
+        self.config = config
+        self.root = Path(config.local_root).expanduser().resolve()
+        self.runs_root = self.root / "runs"
+        self.datasets_root = self.root / "data"
+        self.datasets_root.mkdir(parents=True, exist_ok=True)
+
+    def _validate_user(self, userid: str) -> None:
+        if userid != self.config.local_user_id:
+            raise PermissionError("Local mode only permits the configured local user")
+
+    @staticmethod
+    def _validate_segment(value: str, label: str) -> str:
+        if not value or value in {".", ".."} or Path(value).name != value:
+            raise ValueError(f"Invalid {label}")
+        if os.sep in value or (os.altsep and os.altsep in value):
+            raise ValueError(f"Invalid {label}")
+        return value
+
+    @classmethod
+    def _validate_relative_path(cls, value: str, label: str) -> Path:
+        normalized = value.replace("\\", "/")
+        path = Path(normalized)
+        if path.is_absolute() or not path.parts:
+            raise ValueError(f"Invalid {label}")
+        for part in path.parts:
+            cls._validate_segment(part, label)
+        return path
+
+    def _dataset_sources_path(self, userid: str, jobid: str) -> Path:
+        return self.get_job_path(userid, jobid) / ".dataset-sources.json"
+
+    def get_dataset_source_files(self, userid: str, jobid: str) -> dict[str, Path]:
+        """Return validated referenced source files for a local run."""
+        manifest_path = self._dataset_sources_path(userid, jobid)
+        if not manifest_path.is_file():
+            return {}
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        result: dict[str, Path] = {}
+        for relative_name, source_value in manifest.get("files", {}).items():
+            relative_path = self._validate_relative_path(relative_name, "dataset path")
+            source = Path(source_value)
+            if source.is_symlink() or not source.is_file():
+                raise FileNotFoundError(f"Referenced dataset file is unavailable: {relative_name}")
+            result[relative_path.as_posix()] = source.resolve()
+        return result
+
+    def _write_dataset_sources(
+        self, userid: str, jobid: str, source_files: dict[str, Path]
+    ) -> None:
+        """Atomically persist trusted source references outside renderer-visible metadata."""
+        manifest_path = self._dataset_sources_path(userid, jobid)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=manifest_path.parent,
+            prefix=".dataset-sources-",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            json.dump(
+                {"files": {name: str(path.resolve()) for name, path in source_files.items()}},
+                temp_file,
+                indent=2,
+            )
+            temp_path = Path(temp_file.name)
+        temp_path.replace(manifest_path)
+
+    def get_user_path(self, userid: str) -> str:
+        """Return the local runs directory for the configured user."""
+        self._validate_user(userid)
+        return str(self.runs_root)
+
+    def list_user_ids(self) -> list[str]:
+        """Return the configured user when local run storage exists."""
+        return [self.config.local_user_id] if self.runs_root.is_dir() else []
+
+    def list_jobs(self, userid: str) -> list[str]:
+        """List run IDs owned by the configured local user."""
+        self._validate_user(userid)
+        if not self.runs_root.is_dir():
+            return []
+        return sorted(path.name for path in self.runs_root.iterdir() if path.is_dir())
+
+    def list_datasets(self) -> list[dict[str, Any]]:
+        """List immediate folders in the shared local dataset catalog."""
+        datasets: list[dict[str, Any]] = []
+        for dataset_path in sorted(
+            self.datasets_root.iterdir(), key=lambda path: path.name.lower()
+        ):
+            if not dataset_path.is_dir() or dataset_path.is_symlink():
+                continue
+            files = [path for path in dataset_path.rglob("*") if path.is_file()]
+            datasets.append(
+                {
+                    "name": dataset_path.name,
+                    "file_count": len(files),
+                    "size_bytes": sum(path.stat().st_size for path in files),
+                }
+            )
+        return datasets
+
+    def import_dataset_folder(
+        self,
+        userid: str,
+        jobid: str,
+        *,
+        dataset_name: str | None = None,
+        source_path: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Reference a catalog dataset or external folder from one local run."""
+        if bool(dataset_name) == bool(source_path):
+            raise ValueError("Provide either a dataset name or folder path")
+        if dataset_name:
+            safe_name = self._validate_segment(dataset_name, "dataset name")
+            source = self.datasets_root / safe_name
+        else:
+            source = Path(source_path or "").expanduser()
+            safe_name = source.name
+            self._validate_segment(safe_name, "dataset name")
+        if source.is_symlink() or not source.is_dir():
+            raise ValueError("Dataset folder does not exist or is a symbolic link")
+
+        run_data = self.get_job_path(userid, jobid) / "data"
+        if not run_data.is_dir():
+            raise FileNotFoundError(f"Run does not exist: {jobid}")
+        source_files: list[Path] = []
+        for file_path in source.rglob("*"):
+            if file_path.is_symlink():
+                raise ValueError("Dataset directories may not contain symbolic links")
+            if file_path.is_file():
+                source_files.append(file_path)
+        if not source_files:
+            raise ValueError("Dataset folder does not contain any files")
+
+        for existing in run_data.iterdir():
+            if existing.is_dir():
+                shutil.rmtree(existing)
+            else:
+                existing.unlink()
+        imported: list[dict[str, Any]] = []
+        source_manifest: dict[str, Path] = {}
+        for file_path in source_files:
+            relative_path = Path(safe_name) / file_path.relative_to(source)
+            source_manifest[relative_path.as_posix()] = file_path.resolve()
+            imported.append(
+                {
+                    "name": relative_path.as_posix(),
+                    "content_type": "application/octet-stream",
+                    "file_size_bytes": file_path.stat().st_size,
+                }
+            )
+        self._write_dataset_sources(userid, jobid, source_manifest)
+        return sorted(imported, key=lambda item: item["name"])
+
+    def get_job_path(self, userid: str, jobid: str) -> Path:
+        """Return a validated path below the local runs root."""
+        self._validate_user(userid)
+        safe_jobid = self._validate_segment(jobid, "job ID")
+        return self.runs_root / safe_jobid
+
+    def job_exists(self, userid: str, jobid: str) -> bool:
+        """Return whether the local run directory exists."""
+        return self.get_job_path(userid, jobid).is_dir()
+
+    def create_job(self, userid: str, jobid: str, overwrite: bool = False) -> str:
+        """Create the standard directory layout for one local run."""
+        run_path = self.get_job_path(userid, jobid)
+        if run_path.exists() and not overwrite:
+            raise FileExistsError(f"Run already exists: {jobid}")
+        for name in ("data", "output", "logs"):
+            (run_path / name).mkdir(parents=True, exist_ok=overwrite)
+        return str(run_path)
+
+    def delete_job(self, userid: str, jobid: str) -> None:
+        """Delete one validated local run directory."""
+        run_path = self.get_job_path(userid, jobid)
+        if run_path.exists():
+            shutil.rmtree(run_path)
+
+    def soft_delete_job(self, userid: str, jobid: str) -> dict[str, Any]:
+        """Remove uploaded data while preserving local metadata and results."""
+        run_path = self.get_job_path(userid, jobid)
+        if not run_path.is_dir():
+            raise FileNotFoundError(f"Run does not exist: {jobid}")
+        data_path = run_path / "data"
+        deleted_files: list[str] = []
+        if data_path.is_dir():
+            deleted_files = sorted(
+                str(path.relative_to(run_path)) for path in data_path.rglob("*") if path.is_file()
+            )
+            shutil.rmtree(data_path)
+        data_path.mkdir()
+        self._dataset_sources_path(userid, jobid).unlink(missing_ok=True)
+        preserved_files = sum(1 for path in run_path.rglob("*") if path.is_file())
+        return {
+            "deleted_files": deleted_files,
+            "preserved_files": preserved_files,
+            "status": "DELETED",
+        }
+
+    def upload_dataset(
+        self,
+        userid: str,
+        jobid: str,
+        local_path: Path,
+        remote_name: str | None = None,
+    ) -> str:
+        """Copy dataset files into a local run without following symlinks."""
+        source = Path(local_path)
+        data_path = self.get_job_path(userid, jobid) / "data"
+        if not data_path.is_dir():
+            raise FileNotFoundError(f"Run does not exist: {jobid}")
+        if source.is_symlink():
+            raise ValueError("Dataset source may not be a symbolic link")
+        self._dataset_sources_path(userid, jobid).unlink(missing_ok=True)
+        if source.is_file():
+            relative_path = self._validate_relative_path(
+                remote_name or source.name, "filename"
+            )
+            destination = data_path / relative_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+        elif source.is_dir():
+            for file_path in source.rglob("*"):
+                if file_path.is_symlink():
+                    raise ValueError("Dataset directories may not contain symbolic links")
+                if file_path.is_file():
+                    relative_path = file_path.relative_to(source)
+                    destination = data_path / relative_path
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(file_path, destination)
+        else:
+            raise FileNotFoundError(f"Dataset path does not exist: {source}")
+        return str(data_path)
+
+    def has_data_files(self, userid: str, jobid: str) -> bool:
+        """Return whether a local run contains at least one dataset file."""
+        if self.get_dataset_source_files(userid, jobid):
+            return True
+        data_path = self.get_job_path(userid, jobid) / "data"
+        return data_path.is_dir() and any(path.is_file() for path in data_path.rglob("*"))
+
+    def copy_job_data(
+        self,
+        source_userid: str,
+        source_jobid: str,
+        dest_userid: str,
+        dest_jobid: str,
+    ) -> list[str]:
+        """Copy dataset files between validated local runs."""
+        source_data = self.get_job_path(source_userid, source_jobid) / "data"
+        destination_data = self.get_job_path(dest_userid, dest_jobid) / "data"
+        if not source_data.is_dir() or not destination_data.is_dir():
+            raise FileNotFoundError("Source and destination runs must exist")
+        source_references = self.get_dataset_source_files(source_userid, source_jobid)
+        if source_references:
+            self._write_dataset_sources(dest_userid, dest_jobid, source_references)
+            return sorted(source_references)
+        copied: list[str] = []
+        for source in source_data.rglob("*"):
+            if source.is_symlink():
+                raise ValueError("Dataset directories may not contain symbolic links")
+            if source.is_file():
+                relative_path = source.relative_to(source_data)
+                destination = destination_data / relative_path
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, destination)
+                copied.append(str(relative_path))
+        return sorted(copied)
+
+    def upload_metadata(self, userid: str, jobid: str, metadata: dict[str, Any]) -> str:
+        """Atomically write run metadata as JSON."""
+        run_path = self.get_job_path(userid, jobid)
+        if not run_path.is_dir():
+            raise FileNotFoundError(f"Run does not exist: {jobid}")
+        destination = run_path / "metadata.json"
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=run_path,
+            prefix=".metadata-",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            json.dump(metadata, temp_file, indent=2)
+            temp_path = Path(temp_file.name)
+        temp_path.replace(destination)
+        return str(destination)
+
+    def get_metadata(self, userid: str, jobid: str) -> dict[str, Any]:
+        """Read run metadata, returning an empty dictionary when absent."""
+        metadata_path = self.get_job_path(userid, jobid) / "metadata.json"
+        if not metadata_path.is_file():
+            return {}
+        with metadata_path.open(encoding="utf-8") as metadata_file:
+            value = json.load(metadata_file)
+        if not isinstance(value, dict):
+            raise ValueError("Run metadata must be a JSON object")
+        return value
+
+    def get_results(self, userid: str, jobid: str) -> list[str]:
+        """List files produced under a local run's output directory."""
+        output_path = self.get_job_path(userid, jobid) / "output"
+        if not output_path.is_dir():
+            return []
+        return sorted(
+            str(path.relative_to(output_path))
+            for path in output_path.rglob("*")
+            if path.is_file()
+        )
+
+    def read_rich_outputs(
+        self,
+        userid: str,
+        jobid: str,
+        level: int,
+        index: int,
+    ) -> list[dict[str, Any]]:
+        """Read rich output bundles for one local experiment node."""
+        rich_path = (
+            self.get_job_path(userid, jobid)
+            / "output"
+            / "rich_outputs"
+            / f"ro_{level}_{index}.json"
+        )
+        if not rich_path.is_file():
+            return []
+        try:
+            with rich_path.open(encoding="utf-8") as rich_file:
+                value = json.load(rich_file)
+        except (OSError, json.JSONDecodeError):
+            return []
+        return value if isinstance(value, list) else []

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/local_storage.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/local_storage.py
@@ -6,6 +6,7 @@ import json
 import os
 import shutil
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -215,6 +216,7 @@ class LocalStorage:
             "deleted_files": deleted_files,
             "preserved_files": preserved_files,
             "status": "DELETED",
+            "deleted_at": datetime.now(UTC).isoformat(),
         }
 
     def upload_dataset(

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/manager.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/manager.py
@@ -11,6 +11,7 @@ from . import gcs
 from .backends import get_backend
 from .config import JobConfig
 from .exceptions import DatasetExpiredError
+from .local_storage import LocalStorage
 from .run_details import RunDetails, create_run_details, get_run_details
 
 logger = logging.getLogger(__name__)
@@ -77,6 +78,7 @@ class JobManager:
         self.config = config or JobConfig.from_env()
         _warn_if_unsafe_code_execution(self.config)
         self.backend = get_backend(self.config)
+        self.local_storage = LocalStorage(self.config) if self.config.backend == "local" else None
 
     # User operations
 
@@ -89,6 +91,8 @@ class JobManager:
         Returns:
             GCS path like "gs://bucket/users/{userid}/"
         """
+        if self.local_storage is not None:
+            return self.local_storage.get_user_path(userid)
         return gcs.get_user_path(userid, self.config)
 
     def list_user_ids(self) -> list[str]:
@@ -97,6 +101,8 @@ class JobManager:
         Returns:
             List of user IDs
         """
+        if self.local_storage is not None:
+            return self.local_storage.list_user_ids()
         return gcs.list_user_ids(self.config)
 
     # Job management
@@ -110,6 +116,8 @@ class JobManager:
         Returns:
             List of job IDs
         """
+        if self.local_storage is not None:
+            return self.local_storage.list_jobs(userid)
         return gcs.list_user_jobs(userid, self.config)
 
     def job_exists(self, userid: str, jobid: str) -> bool:
@@ -122,6 +130,8 @@ class JobManager:
         Returns:
             True if job exists
         """
+        if self.local_storage is not None:
+            return self.local_storage.job_exists(userid, jobid)
         return gcs.job_exists(userid, jobid, self.config)
 
     def create_job(self, userid: str, jobid: str, overwrite: bool = False) -> str:
@@ -135,6 +145,8 @@ class JobManager:
         Returns:
             GCS path to created job directory
         """
+        if self.local_storage is not None:
+            return self.local_storage.create_job(userid, jobid, overwrite)
         return gcs.create_job_directory(userid, jobid, self.config, overwrite)
 
     def copy_job_data(
@@ -155,6 +167,10 @@ class JobManager:
         Returns:
             List of copied filenames
         """
+        if self.local_storage is not None:
+            return self.local_storage.copy_job_data(
+                source_userid, source_jobid, dest_userid, dest_jobid
+            )
         return gcs.copy_job_data_files(
             source_userid, source_jobid, dest_userid, dest_jobid, self.config
         )
@@ -261,6 +277,9 @@ class JobManager:
             userid: User identifier
             jobid: Job identifier
         """
+        if self.local_storage is not None:
+            self.local_storage.delete_job(userid, jobid)
+            return
         gcs.delete_job_directory(userid, jobid, self.config)
         gcs.delete_shared_run_index(jobid, self.config)
 
@@ -304,6 +323,11 @@ class JobManager:
                 # Continue with soft delete even if cancellation fails
                 pass
 
+        if self.local_storage is not None:
+            result = self.local_storage.soft_delete_job(userid, jobid)
+            result["cancelled_execution"] = cancelled_execution
+            return result
+
         # Perform soft delete
         result = gcs.soft_delete_job(userid, jobid, self.config)
         result["cancelled_execution"] = cancelled_execution
@@ -322,6 +346,8 @@ class JobManager:
         Returns:
             GCS path like "gs://bucket/users/{userid}/jobs/{jobid}/"
         """
+        if self.local_storage is not None:
+            return str(self.local_storage.get_job_path(userid, jobid))
         return gcs.get_job_path(userid, jobid, self.config)
 
     # Data operations
@@ -340,6 +366,8 @@ class JobManager:
         Returns:
             GCS path where data was uploaded
         """
+        if self.local_storage is not None:
+            return self.local_storage.upload_dataset(userid, jobid, local_path, remote_name)
         return gcs.upload_dataset(userid, jobid, local_path, self.config, remote_name)
 
     def generate_upload_url(
@@ -362,6 +390,8 @@ class JobManager:
         Returns:
             Dictionary with 'upload_url' and 'gcs_path' keys
         """
+        if self.local_storage is not None:
+            raise ValueError("Local jobs use the multipart upload endpoint")
         return gcs.generate_upload_url(
             userid,
             jobid,
@@ -373,6 +403,8 @@ class JobManager:
 
     def has_data_files(self, userid: str, jobid: str) -> bool:
         """Check if a job has any non-placeholder data files."""
+        if self.local_storage is not None:
+            return self.local_storage.has_data_files(userid, jobid)
         return gcs.has_data_files(userid, jobid, self.config)
 
     def expire_datasets(
@@ -409,6 +441,8 @@ class JobManager:
         Returns:
             GCS path to uploaded metadata
         """
+        if self.local_storage is not None:
+            return self.local_storage.upload_metadata(userid, jobid, metadata)
         return gcs.upload_metadata(userid, jobid, metadata, self.config)
 
     def upload_job_args(self, userid: str, jobid: str, args: dict[str, Any]) -> str:
@@ -433,6 +467,8 @@ class JobManager:
         Returns:
             Metadata dictionary
         """
+        if self.local_storage is not None:
+            return self.local_storage.get_metadata(userid, jobid)
         return gcs.get_metadata(userid, jobid, self.config)
 
     def get_job_args(self, userid: str, jobid: str) -> dict[str, Any] | None:
@@ -464,6 +500,9 @@ class JobManager:
             Returns None for runs that don't exist OR exist but are not shared.
             This prevents information leakage about run existence.
         """
+        if self.local_storage is not None:
+            return None
+
         # Fast path: check the shared-run index
         userid = gcs.get_shared_run_index(runid, self.config)
         if userid:
@@ -495,6 +534,8 @@ class JobManager:
             userid: User ID of the run owner
             is_shared: True to share, False to unshare
         """
+        if self.local_storage is not None:
+            raise ValueError("Run sharing is unavailable for local jobs")
         metadata = self.get_metadata(userid, runid) or {}
         metadata["is_shared"] = is_shared
         self.upload_metadata(userid, runid, metadata)
@@ -604,6 +645,8 @@ class JobManager:
         Returns:
             List of GCS paths to result files
         """
+        if self.local_storage is not None:
+            return self.local_storage.get_results(userid, jobid)
         return gcs.get_job_results(userid, jobid, self.config)
 
     def download_results(self, userid: str, jobid: str, local_dir: Path) -> list[Path]:
@@ -617,6 +660,16 @@ class JobManager:
         Returns:
             List of local file paths that were downloaded
         """
+        if self.local_storage is not None:
+            output_path = self.local_storage.get_job_path(userid, jobid) / "output"
+            copied: list[Path] = []
+            for source in output_path.rglob("*"):
+                if source.is_file():
+                    destination = local_dir / source.relative_to(output_path)
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    destination.write_bytes(source.read_bytes())
+                    copied.append(destination)
+            return copied
         return gcs.download_job_results(userid, jobid, local_dir, self.config)
 
     # Convenience methods

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/run_details.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/run_details.py
@@ -8,12 +8,15 @@ file that tracks execution state.
 from __future__ import annotations
 
 import json
+import tempfile
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from .client import get_storage_client
 from .config import JobConfig
+from .local_storage import LocalStorage
 
 
 # Terminal statuses that indicate job completion
@@ -113,6 +116,10 @@ def create_run_details(
         The created RunDetails object
     """
     config = config or JobConfig.from_env()
+    if config.backend == "local":
+        run_details = RunDetails.create_new()
+        _write_local_run_details(userid, runid, run_details, config)
+        return run_details
     client = get_storage_client(config.project_id)
     bucket = client.bucket(config.bucket)
 
@@ -141,6 +148,15 @@ def get_run_details(
         RunDetails object, or None if not found
     """
     config = config or JobConfig.from_env()
+    if config.backend == "local":
+        details_path = LocalStorage(config).get_job_path(userid, runid) / "run_details.json"
+        if not details_path.is_file():
+            return None
+        try:
+            value = json.loads(details_path.read_text(encoding="utf-8"))
+            return RunDetails.from_dict(value) if isinstance(value, dict) else None
+        except (OSError, json.JSONDecodeError):
+            return None
     client = get_storage_client(config.project_id)
     bucket = client.bucket(config.bucket)
 
@@ -173,6 +189,13 @@ def update_run_details(
         Updated RunDetails object
     """
     config = config or JobConfig.from_env()
+    if config.backend == "local":
+        run_details = get_run_details(userid, runid, config) or RunDetails.create_new()
+        value = run_details.to_dict()
+        value.update(updates)
+        updated = RunDetails.from_dict(value)
+        _write_local_run_details(userid, runid, updated, config)
+        return updated
     client = get_storage_client(config.project_id)
     bucket = client.bucket(config.bucket)
 
@@ -274,3 +297,27 @@ def refresh_run_status(
         pass
 
     return run_details
+
+
+def _write_local_run_details(
+    userid: str,
+    runid: str,
+    run_details: RunDetails,
+    config: JobConfig,
+) -> None:
+    """Atomically persist local run details beside canonical metadata."""
+    run_path = LocalStorage(config).get_job_path(userid, runid)
+    if not run_path.is_dir():
+        raise FileNotFoundError(f"Run does not exist: {runid}")
+    destination = run_path / "run_details.json"
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=run_path,
+        prefix=".run-details-",
+        suffix=".tmp",
+        delete=False,
+    ) as temp_file:
+        json.dump(run_details.to_dict(), temp_file, indent=2)
+        temp_path = Path(temp_file.name)
+    temp_path.replace(destination)

--- a/packages/autodiscovery_jobs/tests/test_local_runner.py
+++ b/packages/autodiscovery_jobs/tests/test_local_runner.py
@@ -1,0 +1,186 @@
+"""Tests for managed local subprocess execution."""
+
+from __future__ import annotations
+
+import json
+import stat
+import sys
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from autodiscovery_jobs import JobManager
+from autodiscovery_jobs.backends.local import LocalProcessBackend
+from autodiscovery_jobs.config import JobConfig
+from autodiscovery_jobs.local_runner import LocalProcessRunner
+from autodiscovery_jobs.run_details import (
+    create_run_details,
+    get_run_details,
+    update_run_details,
+)
+
+
+@pytest.fixture
+def runner(tmp_path: Path) -> LocalProcessRunner:
+    """Create a single-slot local runner in a temporary directory."""
+    return LocalProcessRunner(JobConfig(local_root=str(tmp_path)))
+
+
+def wait_for_phase(
+    runner: LocalProcessRunner,
+    execution_id: str,
+    phases: set[str],
+    timeout: float = 5,
+) -> dict:
+    """Wait for a test execution to enter one of the expected phases."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        status = runner.get_status(execution_id)
+        if status["phase"] in phases:
+            return status
+        time.sleep(0.01)
+    raise AssertionError(f"Execution did not reach {phases}")
+
+
+def test_success_and_logs(runner: LocalProcessRunner, tmp_path: Path) -> None:
+    """Persist successful completion and captured output."""
+    execution_id = runner.start(
+        [sys.executable, "-c", "print('completed')"],
+        run_id="run-1",
+        cwd=tmp_path / "work",
+        log_path=tmp_path / "logs" / "run.log",
+    )
+
+    status = wait_for_phase(runner, execution_id, {"SUCCEEDED"})
+
+    assert status["return_code"] == 0
+    assert runner.get_logs(execution_id) == ["completed"]
+
+
+def test_failure_is_persisted(runner: LocalProcessRunner, tmp_path: Path) -> None:
+    """Persist a nonzero process exit as a failed execution."""
+    execution_id = runner.start(
+        [sys.executable, "-c", "raise SystemExit(7)"],
+        run_id="run-1",
+        cwd=tmp_path / "work",
+        log_path=tmp_path / "logs" / "run.log",
+    )
+
+    status = wait_for_phase(runner, execution_id, {"FAILED"})
+
+    assert status["return_code"] == 7
+
+
+def test_cancel_and_concurrency_limit(runner: LocalProcessRunner, tmp_path: Path) -> None:
+    """Cancel a process group and reject a second concurrent execution."""
+    execution_id = runner.start(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        run_id="run-1",
+        cwd=tmp_path / "work-1",
+        log_path=tmp_path / "logs" / "run-1.log",
+    )
+    with pytest.raises(RuntimeError, match="concurrency limit"):
+        runner.start(
+            [sys.executable, "-c", "print('second')"],
+            run_id="run-2",
+            cwd=tmp_path / "work-2",
+            log_path=tmp_path / "logs" / "run-2.log",
+        )
+
+    runner.cancel(execution_id)
+    status = wait_for_phase(runner, execution_id, {"CANCELLED"})
+
+    assert status["phase"] == "CANCELLED"
+
+
+def test_manager_builds_local_engine_command(tmp_path: Path) -> None:
+    """Build the upstream engine command with local paths and provider options."""
+    config = JobConfig(backend="local", local_root=str(tmp_path))
+    manager = JobManager(config)
+    manager.create_job("local", "run-1")
+    source = tmp_path / "table.csv"
+    source.write_text("value\n1\n", encoding="utf-8")
+    manager.upload_dataset("local", "run-1", source)
+    manager.upload_metadata(
+        "local",
+        "run-1",
+        {"datasets": [{"name": "table.csv"}], "name": "Test run"},
+    )
+    manager.backend.runner.start = Mock(return_value="local-execution")
+
+    execution_id = manager.run_job(
+        "local",
+        "run-1",
+        n_experiments=2,
+        model="claude-haiku-4.5",
+        llm_provider="copilot",
+        embedding_provider="copilot",
+    )
+
+    assert execution_id == "local-execution"
+    command = manager.backend.runner.start.call_args.args[0]
+    assert command[:3] == [sys.executable, "-m", "autodiscovery.local_worker"]
+    assert "--backend=process" in command
+    assert "--llm_provider=copilot" in command
+    assert "--embedding_provider=copilot" in command
+    runtime_metadata = tmp_path / "runs" / "run-1" / "work" / ".autodiscovery-metadata.json"
+    assert runtime_metadata.is_file()
+    runtime_datasets = json.loads(runtime_metadata.read_text(encoding="utf-8"))["datasets"]
+    assert runtime_datasets[0]["name"] == "table.csv"
+    alias = tmp_path / "runs" / "run-1" / "work" / "table.csv"
+    assert alias.is_symlink()
+    assert alias.read_text(encoding="utf-8") == "value\n1\n"
+    assert not (tmp_path / "runs" / "run-1" / "data" / "table.csv").stat().st_mode & stat.S_IWUSR
+    assert manager.get_metadata("local", "run-1")["name"] == "Test run"
+
+
+def test_local_runtime_view_flattens_nested_declared_paths(tmp_path: Path) -> None:
+    """Give base and threaded agents one stable basename for every declared local file."""
+    run_path = tmp_path / "run"
+    source = run_path / "data" / "study" / "nested" / "table.csv"
+    source.parent.mkdir(parents=True)
+    source.write_text("value\n1\n", encoding="utf-8")
+
+    runtime_metadata = LocalProcessBackend._prepare_runtime_view(
+        run_path, {"datasets": [{"name": "study/nested/table.csv"}]}
+    )
+
+    assert json.loads(runtime_metadata.read_text(encoding="utf-8"))["datasets"] == [
+        {"name": "table.csv"}
+    ]
+    assert (run_path / "work" / "table.csv").resolve() == source.resolve()
+
+
+def test_local_runtime_view_rejects_duplicate_basenames(tmp_path: Path) -> None:
+    """Fail before model calls when flattening would make dataset paths ambiguous."""
+    run_path = tmp_path / "run"
+    for folder in ("first", "second"):
+        source = run_path / "data" / folder / "table.csv"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(folder, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="filenames must be unique"):
+        LocalProcessBackend._prepare_runtime_view(
+            run_path,
+            {"datasets": [{"name": "first/table.csv"}, {"name": "second/table.csv"}]},
+        )
+
+
+def test_local_run_details_round_trip(tmp_path: Path) -> None:
+    """Persist local lifecycle state without creating a cloud client."""
+    config = JobConfig(backend="local", local_root=str(tmp_path))
+    manager = JobManager(config)
+    manager.create_job("local", "run-1")
+
+    created = create_run_details("local", "run-1", config)
+    updated = update_run_details(
+        "local",
+        "run-1",
+        {"execution_id": "local-123", "status": "RUNNING"},
+        config,
+    )
+
+    assert created.status == "CREATED"
+    assert updated.execution_id == "local-123"
+    assert get_run_details("local", "run-1", config) == updated

--- a/packages/autodiscovery_jobs/tests/test_local_runner.py
+++ b/packages/autodiscovery_jobs/tests/test_local_runner.py
@@ -129,9 +129,10 @@ def test_manager_builds_local_engine_command(tmp_path: Path) -> None:
     runtime_datasets = json.loads(runtime_metadata.read_text(encoding="utf-8"))["datasets"]
     assert runtime_datasets[0]["name"] == "table.csv"
     alias = tmp_path / "runs" / "run-1" / "work" / "table.csv"
-    assert alias.is_symlink()
+    assert not alias.is_symlink()
     assert alias.read_text(encoding="utf-8") == "value\n1\n"
-    assert not (tmp_path / "runs" / "run-1" / "data" / "table.csv").stat().st_mode & stat.S_IWUSR
+    assert alias.stat().st_mode & stat.S_IWUSR == 0
+    assert (tmp_path / "runs" / "run-1" / "data" / "table.csv").stat().st_mode & stat.S_IWUSR
     assert manager.get_metadata("local", "run-1")["name"] == "Test run"
 
 
@@ -149,7 +150,7 @@ def test_local_runtime_view_flattens_nested_declared_paths(tmp_path: Path) -> No
     assert json.loads(runtime_metadata.read_text(encoding="utf-8"))["datasets"] == [
         {"name": "table.csv"}
     ]
-    assert (run_path / "work" / "table.csv").resolve() == source.resolve()
+    assert (run_path / "work" / "table.csv").read_text(encoding="utf-8") == "value\n1\n"
 
 
 def test_local_runtime_view_rejects_duplicate_basenames(tmp_path: Path) -> None:

--- a/packages/autodiscovery_jobs/tests/test_local_storage.py
+++ b/packages/autodiscovery_jobs/tests/test_local_storage.py
@@ -1,0 +1,142 @@
+"""Tests for local filesystem run storage."""
+
+from pathlib import Path
+
+import pytest
+from autodiscovery_jobs import JobManager
+from autodiscovery_jobs.config import JobConfig
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> JobManager:
+    """Create a local-mode manager rooted in a temporary directory."""
+    return JobManager(JobConfig(backend="local", local_root=str(tmp_path)))
+
+
+def test_create_list_and_metadata_round_trip(manager: JobManager) -> None:
+    """Create a complete local run layout and round-trip its metadata."""
+    run_path = Path(manager.create_job("local", "run-1"))
+
+    assert {path.name for path in run_path.iterdir()} == {"data", "output", "logs"}
+    assert manager.list_jobs("local") == ["run-1"]
+    assert manager.job_exists("local", "run-1")
+
+    metadata_path = manager.upload_metadata("local", "run-1", {"name": "Local run"})
+    assert Path(metadata_path).parent == run_path
+    assert manager.get_metadata("local", "run-1") == {"name": "Local run"}
+
+
+def test_catalog_lists_and_imports_dataset_folders(manager: JobManager, tmp_path: Path) -> None:
+    """Create the shared catalog and import catalog or external dataset folders."""
+    storage = manager.local_storage
+    assert storage is not None
+    catalog_dataset = storage.datasets_root / "clinical"
+    catalog_dataset.mkdir()
+    (catalog_dataset / "patients.csv").write_text("id\n1\n", encoding="utf-8")
+    external_dataset = tmp_path / "external-study"
+    external_dataset.mkdir()
+    (external_dataset / "measurements.csv").write_text("value\n2\n", encoding="utf-8")
+    manager.create_job("local", "run-1")
+
+    assert storage.list_datasets() == [
+        {"name": "clinical", "file_count": 1, "size_bytes": 5}
+    ]
+    catalog_files = storage.import_dataset_folder(
+        "local", "run-1", dataset_name="clinical"
+    )
+    external_files = storage.import_dataset_folder(
+        "local", "run-1", source_path=str(external_dataset)
+    )
+
+    run_data = Path(storage.get_job_path("local", "run-1")) / "data"
+    assert catalog_files[0]["name"] == "clinical/patients.csv"
+    assert external_files[0]["name"] == "external-study/measurements.csv"
+    assert not (run_data / "clinical" / "patients.csv").exists()
+    assert not (run_data / "external-study" / "measurements.csv").exists()
+    assert storage.get_dataset_source_files("local", "run-1") == {
+        "external-study/measurements.csv": (external_dataset / "measurements.csv").resolve()
+    }
+
+
+@pytest.mark.parametrize("jobid", ["", ".", "..", "../outside", "nested/run"])
+def test_rejects_run_path_traversal(manager: JobManager, jobid: str) -> None:
+    """Reject run IDs that could escape or add hierarchy below the runs root."""
+    with pytest.raises(ValueError, match="Invalid job ID"):
+        manager.create_job("local", jobid)
+
+
+def test_rejects_other_users(manager: JobManager) -> None:
+    """Prevent hosted identities from crossing into single-user local storage."""
+    with pytest.raises(PermissionError, match="configured local user"):
+        manager.list_jobs("another-user")
+
+
+def test_delete_only_removes_selected_run(manager: JobManager) -> None:
+    """Delete one run without affecting neighboring local runs."""
+    manager.create_job("local", "run-1")
+    manager.create_job("local", "run-2")
+
+    manager.delete_job("local", "run-1")
+
+    assert manager.list_jobs("local") == ["run-2"]
+
+
+def test_upload_and_copy_dataset_files(manager: JobManager, tmp_path: Path) -> None:
+    """Upload local files and preserve nested paths when forking run data."""
+    source = tmp_path / "source"
+    (source / "nested").mkdir(parents=True)
+    (source / "table.csv").write_text("value\n1\n", encoding="utf-8")
+    (source / "nested" / "notes.txt").write_text("notes", encoding="utf-8")
+    manager.create_job("local", "source-run")
+    manager.create_job("local", "destination-run")
+
+    data_path = Path(manager.upload_dataset("local", "source-run", source))
+    copied = manager.copy_job_data("local", "source-run", "local", "destination-run")
+
+    assert manager.has_data_files("local", "source-run")
+    assert (data_path / "table.csv").read_text(encoding="utf-8") == "value\n1\n"
+    assert copied == ["nested/notes.txt", "table.csv"]
+    destination = Path(manager.get_job_path("local", "destination-run")) / "data"
+    assert (destination / "nested" / "notes.txt").read_text(encoding="utf-8") == "notes"
+
+
+def test_upload_rejects_unsafe_filename(manager: JobManager, tmp_path: Path) -> None:
+    """Prevent multipart filenames from escaping the run data directory."""
+    source = tmp_path / "source.csv"
+    source.write_text("value\n1\n", encoding="utf-8")
+    manager.create_job("local", "run-1")
+
+    with pytest.raises(ValueError, match="Invalid filename"):
+        manager.upload_dataset("local", "run-1", source, remote_name="../outside.csv")
+
+
+def test_upload_preserves_valid_relative_path(manager: JobManager, tmp_path: Path) -> None:
+    """Preserve folder structure selected by the local browser picker."""
+    source = tmp_path / "source.csv"
+    source.write_text("value\n1\n", encoding="utf-8")
+    run_path = Path(manager.create_job("local", "run-1"))
+
+    manager.upload_dataset(
+        "local", "run-1", source, remote_name="selected-folder/nested/source.csv"
+    )
+
+    assert (run_path / "data" / "selected-folder" / "nested" / "source.csv").is_file()
+
+
+def test_soft_delete_removes_data_and_preserves_results(
+    manager: JobManager, tmp_path: Path
+) -> None:
+    """Preserve local run artifacts while removing uploaded data."""
+    source = tmp_path / "source.csv"
+    source.write_text("value\n1\n", encoding="utf-8")
+    run_path = Path(manager.create_job("local", "run-1"))
+    manager.upload_dataset("local", "run-1", source)
+    manager.upload_metadata("local", "run-1", {"name": "Run"})
+    (run_path / "output" / "report.html").write_text("report", encoding="utf-8")
+
+    result = manager.soft_delete_job("local", "run-1")
+
+    assert result["status"] == "DELETED"
+    assert not (run_path / "data" / "source.csv").exists()
+    assert (run_path / "metadata.json").is_file()
+    assert (run_path / "output" / "report.html").is_file()

--- a/packages/autodiscovery_jobs/tests/test_local_storage.py
+++ b/packages/autodiscovery_jobs/tests/test_local_storage.py
@@ -137,6 +137,7 @@ def test_soft_delete_removes_data_and_preserves_results(
     result = manager.soft_delete_job("local", "run-1")
 
     assert result["status"] == "DELETED"
+    assert result["deleted_at"]
     assert not (run_path / "data" / "source.csv").exists()
     assert (run_path / "metadata.json").is_file()
     assert (run_path / "output" / "report.html").is_file()


### PR DESCRIPTION
## Summary
- Adds the local job/runtime backend for desktop execution.
- Persists and forwards provider/model selections.
- Keeps user datasets isolated by copying worker inputs instead of modifying source files.

## Validation
- Direct local dataset-isolation check passed: source stays writable and worker copy is read-only.
- Local Copilot readiness and worker configuration were exercised in a real local run.

## Stack
Depends on the Copilot provider PR below it.