### PR TITLE
Add local desktop UI and provider onboarding

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -8,6 +8,7 @@ from root import root_api
 from runs import runs_api
 from user import user_api
 from utils import error, glog, userid_logging
+from utils.provider_credentials import load_provider_credentials
 from werkzeug.exceptions import HTTPException
 from werkzeug.middleware.proxy_fix import ProxyFix
 
@@ -19,6 +20,9 @@ def create_app() -> ProxyFix:
     level = os.environ.get("LOG_LEVEL", default=logging.INFO)
     logging.basicConfig(level=level, handlers=handlers, force=True)
     logging.root.setLevel(level)
+
+    if os.environ.get("JOB_BACKEND") == "local":
+        load_provider_credentials()
 
     app = Flask("api")
     userid_logging.instrument(app, logging.root)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,5 +5,6 @@ python-json-logger==2.0.2
 PyJWT==2.13.0
 bcrypt==5.0.0
 cryptography==48.0.1
+keyring>=25.6.0,<26
 requests==2.33.0
 pydantic==2.12.5

--- a/api/runs/models.py
+++ b/api/runs/models.py
@@ -257,6 +257,9 @@ class RunModel(BaseModel):
     dataset_expires_at: str | None = Field(
         None, description="ISO timestamp when the dataset expires"
     )
+    estimated_cost_usd: float | None = Field(
+        None, description="API-equivalent estimate from actual local token usage"
+    )
 
 
 class GetRunMetadataRequestModel(BaseModel):

--- a/api/runs/runs_api.py
+++ b/api/runs/runs_api.py
@@ -4,6 +4,7 @@ This module provides authenticated endpoints for users to create and manage
 their own autodiscovery experiment runs.
 """
 
+import json
 import os
 import tempfile
 import uuid
@@ -12,6 +13,8 @@ from pathlib import Path
 from google.cloud import storage
 from urllib.parse import urlparse
 import logging
+import shutil
+import subprocess
 
 
 from flask import Blueprint, current_app, jsonify, request
@@ -28,6 +31,13 @@ from utils.credits import (
     get_job_stats,
 )
 from utils.experiments import ExperimentTree
+from utils import copilot_login
+from utils.provider_credentials import (
+    delete_provider_configuration,
+    load_provider_credentials,
+    provider_configuration,
+    save_provider_configuration,
+)
 from werkzeug.exceptions import BadRequest
 
 from runs.models import (
@@ -111,6 +121,52 @@ UPLOAD_URL_EXPIRATION_SECONDS = 3600  # 1 hour
 # Users whose runs are publicly accessible (can be queried by anyone)
 PUBLIC_USERS = {"samples"}
 
+_FALLBACK_MODEL_PRICES = (
+    ("opus", 5.0, 25.0),
+    ("sonnet", 3.0, 15.0),
+    ("haiku", 1.0, 5.0),
+    ("gpt-5.4", 2.5, 15.0),
+    ("gpt-5", 0.25, 2.0),
+    ("gemini-3", 0.5, 3.0),
+)
+
+
+def _estimate_local_copilot_cost(job_path: Path, metadata: dict | None) -> float | None:
+    """Estimate API-equivalent USD from actual local Copilot token events."""
+    if (metadata or {}).get("llm_provider") != "copilot":
+        return None
+    events_path = job_path / "output" / "llm_usage_events.jsonl"
+    if not events_path.is_file():
+        return None
+    pricing = (metadata or {}).get("model_pricing") or {}
+    total_cost = 0.0
+    event_count = 0
+    for line in events_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        usage = event.get("usage") or {}
+        prompt_tokens = max(0, int(usage.get("prompt_tokens") or 0))
+        completion_tokens = max(0, int(usage.get("completion_tokens") or 0))
+        if prompt_tokens == 0 and completion_tokens == 0:
+            continue
+        model = str(event.get("model") or "")
+        model_price = pricing.get(model) or {}
+        input_rate = model_price.get("input_per_million_usd")
+        output_rate = model_price.get("output_per_million_usd")
+        if not isinstance(input_rate, (int, float)) or not isinstance(
+            output_rate, (int, float)
+        ):
+            _, input_rate, output_rate = next(
+                (entry for entry in _FALLBACK_MODEL_PRICES if entry[0] in model.lower()),
+                ("default", 3.0, 15.0),
+            )
+        total_cost += (prompt_tokens / 1_000_000) * input_rate
+        total_cost += (completion_tokens / 1_000_000) * output_rate
+        event_count += 1
+    return round(total_cost, 6) if event_count else None
+
 # AutoDiscovery's own frontend base URL, used to build a link back to the
 # source experiment when handing a user off to Asta.
 AUTODISCOVERY_BASE_URL = os.environ.get("AUTODISCOVERY_BASE_URL", "https://autodiscovery.allen.ai")
@@ -178,6 +234,216 @@ def create() -> Blueprint:
                 "hosted_features": not is_local,
             }
         )
+
+    def local_provider_configuration() -> dict:
+        """Return fast, secret-free provider configuration state."""
+        configured_by_env = any(
+            os.environ.get(name) for name in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+        )
+        configured_in_keychain = False
+        copilot_home = Path(
+            os.environ.get(
+                "AUTODISCOVERY_COPILOT_HOME",
+                Path.home() / ".copilot" / "autodiscovery",
+            )
+        )
+        if os.uname().sysname == "Darwin":
+            result = subprocess.run(
+                ["security", "find-generic-password", "-s", "copilot-cli"],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=5,
+            )
+            configured_in_keychain = result.returncode == 0 and (
+                copilot_home / "config.json"
+            ).is_file()
+        return {
+            "copilot": {"configured": configured_by_env or configured_in_keychain},
+            **provider_configuration(),
+        }
+
+    @api.route("/providers", methods=["GET"])
+    def providers():
+        """Return provider readiness without credentials or account identifiers."""
+        config = JobConfig.from_env()
+        if config.backend == "local":
+            load_provider_credentials()
+        openai_ready = bool(os.environ.get("OPENAI_API_KEY"))
+        vertex_ready = bool(
+            os.environ.get("VERTEX_ACCESS_TOKEN")
+            or os.environ.get("GOOGLE_OAUTH_ACCESS_TOKEN")
+        )
+        current_models = []
+        if openai_ready:
+            current_models.extend(["gpt-4o", "o4-mini"])
+        if vertex_ready:
+            current_models.append("gemini-3-flash-preview")
+        current_ready = openai_ready or vertex_ready
+        provider_list = [
+            {
+                "id": "current",
+                "name": "OpenAI / Google Vertex",
+                "status": "ready" if current_ready else "error",
+                "code": "READY" if current_ready else "CREDENTIALS_REQUIRED",
+                "message": (
+                    "External OpenAI or Google Vertex credentials are available."
+                    if current_ready
+                    else "No OpenAI or Google Vertex credentials were detected."
+                ),
+                "remediation": None if current_ready else "Configure provider credentials.",
+                "embedding_ready": openai_ready,
+                "models": [{"id": model, "name": model, "vision": True} for model in current_models],
+            }
+        ]
+        copilot_configured = (
+            config.backend != "local"
+            or local_provider_configuration()["copilot"]["configured"]
+        )
+        if not copilot_configured:
+            provider_list.append(
+                {
+                    "id": "copilot",
+                    "name": "GitHub Copilot",
+                    "status": "error",
+                    "code": "AUTH_REQUIRED",
+                    "message": "Copilot is not connected.",
+                    "remediation": "Connect GitHub Copilot in Settings.",
+                    "embedding_ready": False,
+                    "models": [],
+                }
+            )
+        else:
+            from autodiscovery.copilot import doctor
+
+            diagnostic = doctor()
+            provider_list.append(
+                {
+                    "id": "copilot",
+                    "name": "GitHub Copilot",
+                    "status": diagnostic["status"],
+                    "code": diagnostic["code"],
+                    "message": diagnostic["message"],
+                    "remediation": diagnostic["remediation"],
+                    "embedding_ready": diagnostic["status"] == "ready",
+                    "models": diagnostic["models"],
+                }
+            )
+        return jsonify({"providers": provider_list})
+
+    @api.route("/providers/configuration", methods=["GET"])
+    @requires_auth()
+    def get_provider_configuration():
+        if JobConfig.from_env().backend != "local":
+            return jsonify({"error": "Not found"}), 404
+        return jsonify({"providers": local_provider_configuration()})
+
+    @api.route("/providers/<provider>/configuration", methods=["PUT", "DELETE"])
+    @requires_auth()
+    def configure_provider(provider: str):
+        if JobConfig.from_env().backend != "local":
+            return jsonify({"error": "Not found"}), 404
+        try:
+            if request.method == "DELETE":
+                delete_provider_configuration(provider)
+            else:
+                save_provider_configuration(provider, request.get_json(silent=True) or {})
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        return jsonify({"providers": local_provider_configuration()})
+
+    @api.route("/providers/copilot/login", methods=["POST"])
+    @requires_auth()
+    def start_copilot_login():
+        config = JobConfig.from_env()
+        if config.backend != "local":
+            return jsonify({"error": "Not found"}), 404
+        executable = os.environ.get("COPILOT_CLI_PATH") or shutil.which("copilot")
+        if not executable or not Path(executable).is_file():
+            return jsonify({"error": "Copilot CLI is not installed"}), 409
+        return jsonify(copilot_login.start(executable, config.local_root)), 202
+
+    @api.route("/providers/copilot/login", methods=["GET"])
+    @requires_auth()
+    def copilot_login_status():
+        if JobConfig.from_env().backend != "local":
+            return jsonify({"error": "Not found"}), 404
+        return jsonify(copilot_login.status())
+
+    @api.route("/providers/copilot/configuration", methods=["DELETE"])
+    @requires_auth()
+    def disconnect_copilot():
+        if JobConfig.from_env().backend != "local":
+            return jsonify({"error": "Not found"}), 404
+        if any(os.environ.get(name) for name in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")):
+            return jsonify({"error": "Copilot authentication is supplied by an environment variable"}), 409
+        if os.uname().sysname != "Darwin":
+            return jsonify({"error": "Copilot disconnect is only available on macOS"}), 501
+        while True:
+            result = subprocess.run(
+                ["security", "delete-generic-password", "-s", "copilot-cli"],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            if result.returncode != 0:
+                break
+        return jsonify({"message": "Copilot disconnected"})
+
+    def get_local_storage():
+        manager = get_job_manager()
+        if manager.config.backend != "local" or manager.local_storage is None:
+            raise FileNotFoundError("Local dataset catalog is not available")
+        return manager.local_storage
+
+    @api.route("/local-datasets", methods=["GET"])
+    @requires_auth()
+    def list_local_datasets():
+        try:
+            storage = get_local_storage()
+        except FileNotFoundError:
+            return jsonify({"error": "Not found"}), 404
+        return jsonify(
+            {"datasets": storage.list_datasets(), "catalog_path": str(storage.datasets_root)}
+        )
+
+    @api.route("/local-datasets/browse", methods=["POST"])
+    @requires_auth()
+    def browse_local_dataset_folder():
+        try:
+            get_local_storage()
+        except FileNotFoundError:
+            return jsonify({"error": "Not found"}), 404
+        if os.uname().sysname != "Darwin":
+            return jsonify({"error": "Native folder selection is only available on macOS"}), 501
+        result = subprocess.run(
+            [
+                "osascript",
+                "-e",
+                'POSIX path of (choose folder with prompt "Choose an AutoDiscovery dataset folder")',
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        return jsonify({"path": result.stdout.strip().rstrip("/") if result.returncode == 0 else None})
+
+    @api.route("/<runid>/local-datasets/import", methods=["POST"])
+    @requires_auth()
+    def import_local_dataset(runid: str):
+        body = request.get_json(silent=True) or {}
+        try:
+            files = get_local_storage().import_dataset_folder(
+                request.user.get("sub"),
+                runid,
+                dataset_name=body.get("dataset_name"),
+                source_path=body.get("source_path"),
+            )
+        except FileNotFoundError:
+            return jsonify({"error": "Not found"}), 404
+        except (PermissionError, ValueError) as exc:
+            return jsonify({"error": str(exc)}), 400
+        return jsonify({"files": files})
 
     @api.route("/create", methods=["POST"])
     @requires_auth(check_permissions=[PermissionType.HIGHER_UPLOAD_LIMIT])
@@ -447,7 +713,7 @@ def create() -> Blueprint:
         def _build_run_model(run_id: str) -> RunModel | None:
             # Parallelize I/O-heavy GCS calls to reduce tail latency.
             try:
-                run_details = get_run_details(req.userid, run_id)
+                run_details = get_run_details(req.userid, run_id, job_manager.config)
             except Exception as e:
                 app_logger.error(f"Failed to get run details for {run_id}: {e}")
                 run_details = None
@@ -508,6 +774,13 @@ def create() -> Blueprint:
                     run_metadata_model.parent_run_name if run_metadata_model else None
                 ),
                 dataset_expires_at=dataset_expires_at,
+                estimated_cost_usd=(
+                    _estimate_local_copilot_cost(
+                        Path(job_manager.get_job_path(req.userid, run_id)), metadata_dict
+                    )
+                    if job_manager.config.backend == "local"
+                    else None
+                ),
             )
 
         if sliced_run_ids:
@@ -568,10 +841,10 @@ def create() -> Blueprint:
             path = manager.get_job_path(req.userid, req.runid)
 
             try:
-                run_details = refresh_run_status(req.userid, req.runid)
+                run_details = refresh_run_status(req.userid, req.runid, manager.config)
             except Exception as e:
                 current_app.logger.error(f"Failed to refresh run status for {req.runid}: {e}")
-                run_details = get_run_details(req.userid, req.runid)
+                run_details = get_run_details(req.userid, req.runid, manager.config)
 
             # Get job stats
             try:
@@ -635,6 +908,11 @@ def create() -> Blueprint:
                     run_metadata_model.parent_run_name if run_metadata_model else None
                 ),
                 dataset_expires_at=dataset_expires_at,
+                estimated_cost_usd=(
+                    _estimate_local_copilot_cost(Path(path), metadata_dict)
+                    if manager.config.backend == "local"
+                    else None
+                ),
             )
 
             return jsonify(run_model.model_dump()), 200

--- a/api/tests/test_copilot_login.py
+++ b/api/tests/test_copilot_login.py
@@ -1,0 +1,47 @@
+"""Tests for managed Copilot OAuth login output."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from utils import copilot_login
+
+
+def test_login_status_extracts_device_code_and_url(monkeypatch, tmp_path) -> None:
+    """Expose the temporary device code that the official CLI prints for the user."""
+    output_path = tmp_path / "copilot-login.log"
+    output_path.write_text(
+        "Open https://github.com/login/device and enter code ABCD-EFGH\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(copilot_login, "_output_path", output_path)
+    monkeypatch.setattr(copilot_login, "_process", SimpleNamespace(poll=lambda: None))
+
+    result = copilot_login.status()
+
+    assert result["phase"] == "running"
+    assert result["device_code"] == "ABCD-EFGH"
+    assert result["verification_url"] == "https://github.com/login/device"
+
+
+def test_login_uses_autodiscovery_copilot_home(monkeypatch, tmp_path) -> None:
+    """Write login state to the same isolated home used by the SDK client."""
+    copilot_home = tmp_path / "copilot-home"
+    calls = []
+
+    class FakeProcess:
+        def poll(self):
+            return None
+
+    monkeypatch.setenv("AUTODISCOVERY_COPILOT_HOME", str(copilot_home))
+    monkeypatch.setattr(copilot_login, "_process", None)
+    monkeypatch.setattr(
+        copilot_login.subprocess,
+        "Popen",
+        lambda command, **kwargs: calls.append((command, kwargs)) or FakeProcess(),
+    )
+
+    copilot_login.start("/runtime/copilot", str(tmp_path / "local"))
+
+    assert calls[0][0] == ["/runtime/copilot", "--no-color", "login"]
+    assert calls[0][1]["env"]["COPILOT_HOME"] == str(copilot_home)

--- a/api/tests/test_local_runtime.py
+++ b/api/tests/test_local_runtime.py
@@ -40,6 +40,39 @@ def test_runtime_config_preserves_hosted_default(monkeypatch) -> None:
     }
 
 
+def test_provider_catalog_is_sanitized(monkeypatch) -> None:
+    monkeypatch.setenv("JOB_BACKEND", "local")
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "configured")
+    monkeypatch.setattr(runs_api, "load_provider_credentials", lambda: None)
+    monkeypatch.setattr(
+        runs_api,
+        "provider_configuration",
+        lambda: {"openai": {"configured": False}, "vertex": {"configured": False}},
+    )
+    monkeypatch.setattr(
+        "autodiscovery.copilot.doctor",
+        lambda: {
+            "status": "ready",
+            "code": "READY",
+            "message": "Ready",
+            "remediation": None,
+            "models": [{"id": "model-1", "name": "Model 1", "vision": True}],
+            "account": {"authenticated": True, "label": "not-exposed"},
+            "runtime": {"path": "/private/path"},
+        },
+    )
+    app = Flask(__name__)
+    app.register_blueprint(runs_api.create(), url_prefix="/api/runs")
+
+    response = app.test_client().get("/api/runs/providers")
+    payload = response.get_json()
+
+    copilot = next(provider for provider in payload["providers"] if provider["id"] == "copilot")
+    assert copilot["models"] == [{"id": "model-1", "name": "Model 1", "vision": True}]
+    assert "account" not in copilot
+    assert "/private/path" not in response.get_data(as_text=True)
+
+
 def test_local_manager_crud_avoids_gcs(tmp_path: Path) -> None:
     manager = JobManager(JobConfig(backend="local", local_root=str(tmp_path)))
 
@@ -70,3 +103,24 @@ def test_local_experiment_tree_reads_output(tmp_path: Path) -> None:
 
     assert len(tree) == 1
     assert tree.get_node("node_0_1").hypothesis == "Local hypothesis"
+
+
+def test_local_copilot_cost_uses_actual_token_events(tmp_path: Path) -> None:
+    output = tmp_path / "output"
+    output.mkdir()
+    (output / "llm_usage_events.jsonl").write_text(
+        json.dumps(
+            {
+                "model": "claude-sonnet-4.6",
+                "usage": {"prompt_tokens": 1_000_000, "completion_tokens": 100_000},
+            }
+        )
+        + "\nnot-json\n",
+        encoding="utf-8",
+    )
+
+    estimate = runs_api._estimate_local_copilot_cost(
+        tmp_path, {"llm_provider": "copilot"}
+    )
+
+    assert estimate == 4.5

--- a/api/tests/test_provider_credentials.py
+++ b/api/tests/test_provider_credentials.py
@@ -1,0 +1,75 @@
+"""Tests for local AI provider credential persistence."""
+
+from __future__ import annotations
+
+import os
+
+import keyring.backend
+import keyring.errors
+from utils import provider_credentials
+
+
+class MemoryKeyring(keyring.backend.KeyringBackend):
+    """Minimal in-memory backend that never touches the real user Keychain."""
+
+    priority = 1
+
+    def __init__(self) -> None:
+        self.values: dict[tuple[str, str], str] = {}
+
+    def get_password(self, servicename: str, username: str) -> str | None:
+        return self.values.get((servicename, username))
+
+    def set_password(self, servicename: str, username: str, password: str) -> None:
+        self.values[(servicename, username)] = password
+
+    def delete_password(self, servicename: str, username: str) -> None:
+        try:
+            del self.values[(servicename, username)]
+        except KeyError as exc:
+            raise keyring.errors.PasswordDeleteError from exc
+
+
+def test_save_load_and_delete_provider_credentials(monkeypatch) -> None:
+    """Persist secrets without returning them and restore them for worker inheritance."""
+    backend = MemoryKeyring()
+    monkeypatch.setattr(provider_credentials.keyring, "get_keyring", lambda: backend)
+    monkeypatch.setattr(provider_credentials.keyring, "get_password", backend.get_password)
+    monkeypatch.setattr(provider_credentials.keyring, "set_password", backend.set_password)
+    monkeypatch.setattr(provider_credentials.keyring, "delete_password", backend.delete_password)
+    for env_name in (
+        "OPENAI_API_KEY",
+        "VERTEX_ACCESS_TOKEN",
+        "VERTEX_PROJECT_ID",
+        "VERTEX_LOCATION",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+
+    provider_credentials.save_provider_configuration("openai", {"api_key": "sk-secret"})
+    provider_credentials.save_provider_configuration(
+        "vertex",
+        {"access_token": "vertex-secret", "project_id": "study-project", "location": "us-west1"},
+    )
+    status = provider_credentials.provider_configuration()
+
+    assert status == {
+        "openai": {"configured": True},
+        "vertex": {"configured": True, "project_id": "study-project", "location": "us-west1"},
+    }
+    assert "secret" not in repr(status)
+    monkeypatch.delenv("OPENAI_API_KEY")
+    provider_credentials.load_provider_credentials()
+    assert os.environ["OPENAI_API_KEY"] == "sk-secret"
+
+    provider_credentials.delete_provider_configuration("openai")
+    assert provider_credentials.provider_configuration()["openai"] == {"configured": False}
+
+
+def test_rejects_missing_secret() -> None:
+    """Require the provider's secret credential before persisting configuration."""
+    try:
+        provider_credentials.save_provider_configuration("openai", {"api_key": ""})
+    except ValueError as exc:
+        assert "Api Key is required" in str(exc)
+    else:
+        raise AssertionError("Expected an empty OpenAI key to be rejected")

--- a/api/utils/copilot_login.py
+++ b/api/utils/copilot_login.py
@@ -1,0 +1,78 @@
+"""Managed Copilot OAuth login process for the local application."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any
+
+_ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+_DEVICE_CODE = re.compile(r"\b[A-Z0-9]{4}-[A-Z0-9]{4}\b", re.IGNORECASE)
+_URL = re.compile(r"https://[^\s]+")
+_MAX_OUTPUT_CHARS = 8_000
+
+_lock = threading.Lock()
+_process: subprocess.Popen[str] | None = None
+_output_path: Path | None = None
+
+
+def start(executable: str, local_root: str) -> dict[str, Any]:
+    """Start a fresh official login flow and capture its user-facing output."""
+    global _process, _output_path
+    with _lock:
+        if _process is not None and _process.poll() is None:
+            _process.terminate()
+        state_dir = Path(local_root).expanduser().resolve() / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        _output_path = state_dir / "copilot-login.log"
+        output = _output_path.open("w", encoding="utf-8")
+        try:
+            environment = os.environ.copy()
+            environment["COPILOT_HOME"] = os.environ.get(
+                "AUTODISCOVERY_COPILOT_HOME",
+                str(Path.home() / ".copilot" / "autodiscovery"),
+            )
+            _process = subprocess.Popen(
+                [executable, "--no-color", "login"],
+                env=environment,
+                stdout=output,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                start_new_session=True,
+            )
+        finally:
+            output.close()
+    return status()
+
+
+def status() -> dict[str, Any]:
+    """Return bounded, parsed login output suitable for the local renderer."""
+    with _lock:
+        process = _process
+        output_path = _output_path
+    output = ""
+    if output_path and output_path.is_file():
+        output = _ANSI_ESCAPE.sub("", output_path.read_text(encoding="utf-8", errors="replace"))
+        output = output[-_MAX_OUTPUT_CHARS:]
+    code_match = _DEVICE_CODE.search(output)
+    url_match = _URL.search(output)
+    return_code = process.poll() if process is not None else None
+    if process is None:
+        phase = "idle"
+    elif return_code is None:
+        phase = "running"
+    elif return_code == 0:
+        phase = "completed"
+    else:
+        phase = "failed"
+    return {
+        "phase": phase,
+        "device_code": code_match.group(0).upper() if code_match else None,
+        "verification_url": url_match.group(0).rstrip(".,)") if url_match else None,
+        "output": output,
+        "return_code": return_code,
+    }

--- a/api/utils/provider_credentials.py
+++ b/api/utils/provider_credentials.py
@@ -1,0 +1,87 @@
+"""Keychain-backed credentials for local AI providers."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from typing import Any
+
+import keyring
+
+_SERVICE = "org.allenai.autodiscovery.providers"
+_FIELDS = {
+    "openai": {"api_key": "OPENAI_API_KEY"},
+    "vertex": {
+        "access_token": "VERTEX_ACCESS_TOKEN",
+        "project_id": "VERTEX_PROJECT_ID",
+        "location": "VERTEX_LOCATION",
+    },
+}
+_SECRET_FIELDS = {"openai": {"api_key"}, "vertex": {"access_token"}}
+
+
+def _account(provider: str, field: str) -> str:
+    return f"{provider}.{field}"
+
+
+def load_provider_credentials() -> None:
+    """Load saved provider values into the API environment for worker inheritance."""
+    for provider, fields in _FIELDS.items():
+        for field, env_name in fields.items():
+            if os.environ.get(env_name):
+                continue
+            value = keyring.get_password(_SERVICE, _account(provider, field))
+            if value:
+                os.environ[env_name] = value
+
+
+def provider_configuration() -> dict[str, dict[str, Any]]:
+    """Return non-secret provider configuration state."""
+    result: dict[str, dict[str, Any]] = {}
+    for provider, fields in _FIELDS.items():
+        values = {
+            field: os.environ.get(env_name)
+            or keyring.get_password(_SERVICE, _account(provider, field))
+            for field, env_name in fields.items()
+        }
+        public_values = {
+            field: value
+            for field, value in values.items()
+            if field not in _SECRET_FIELDS[provider] and value
+        }
+        required = _SECRET_FIELDS[provider]
+        result[provider] = {
+            "configured": all(bool(values.get(field)) for field in required),
+            **public_values,
+        }
+    return result
+
+
+def save_provider_configuration(provider: str, values: dict[str, Any]) -> None:
+    """Persist allowed provider fields and update the live API environment."""
+    if provider not in _FIELDS:
+        raise ValueError("Unsupported provider")
+    allowed_fields = _FIELDS[provider]
+    required = _SECRET_FIELDS[provider]
+    for field in required:
+        if not str(values.get(field) or "").strip():
+            raise ValueError(f"{field.replace('_', ' ').title()} is required")
+    for field, env_name in allowed_fields.items():
+        value = str(values.get(field) or "").strip()
+        if not value:
+            if field == "location" and provider == "vertex":
+                value = "global"
+            else:
+                continue
+        keyring.set_password(_SERVICE, _account(provider, field), value)
+        os.environ[env_name] = value
+
+
+def delete_provider_configuration(provider: str) -> None:
+    """Remove all saved values for a provider from Keychain and the live environment."""
+    if provider not in _FIELDS:
+        raise ValueError("Unsupported provider")
+    for field, env_name in _FIELDS[provider].items():
+        with contextlib.suppress(keyring.errors.PasswordDeleteError):
+            keyring.delete_password(_SERVICE, _account(provider, field))
+        os.environ.pop(env_name, None)

--- a/ui/src/app/api/RunsApi.ts
+++ b/ui/src/app/api/RunsApi.ts
@@ -43,6 +43,17 @@ export interface RunMetadataFromApi {
     evidence_weight: number | null;
     warmstart_experiments: string | null;
     n_warmstart: number | null;
+    llm_provider?: 'current' | 'copilot' | null;
+    embedding_provider?: 'current' | 'copilot' | null;
+    model?: string | null;
+    belief_model?: string | null;
+    vision_model?: string | null;
+    embedding_model?: string | null;
+    embedding_dimensions?: number | null;
+    model_pricing?: Record<
+        string,
+        { input_per_million_usd: number; output_per_million_usd: number }
+    > | null;
     // Lineage
     parent_run_id?: string | null;
     parent_run_name?: string | null;
@@ -64,6 +75,7 @@ export interface RunFromApi {
     parent_run_name?: string | null;
     dataset_expires_at?: string | null;
     can_explore_with_asta?: boolean;
+    estimated_cost_usd?: number | null;
 }
 
 export interface UploadDatasetResponseBody {
@@ -77,6 +89,66 @@ export interface GenerateUploadUrlResponseBody {
     gcs_path: string;
     filename: string;
     expires_at_unix: number;
+}
+
+export interface RuntimeConfigResponseBody {
+    deployment_mode: 'hosted' | 'local';
+    upload_transport: 'presigned' | 'api';
+    hosted_features: boolean;
+}
+
+export interface ProviderModel {
+    id: string;
+    name: string;
+    vision: boolean;
+    reasoning_efforts?: string[];
+    pricing?: {
+        input_per_million_usd: number;
+        output_per_million_usd: number;
+    };
+}
+
+export interface ProviderInfo {
+    id: 'current' | 'copilot';
+    name: string;
+    status: 'ready' | 'degraded' | 'error';
+    code: string;
+    message: string;
+    remediation: string | null;
+    embedding_ready: boolean;
+    models: ProviderModel[];
+}
+
+export interface ProvidersResponseBody {
+    providers: ProviderInfo[];
+}
+
+export interface ProviderConfigurationResponseBody {
+    providers: {
+        copilot: { configured: boolean };
+        openai: { configured: boolean };
+        vertex: { configured: boolean; project_id?: string; location?: string };
+    };
+}
+
+export interface CopilotLoginStatus {
+    phase: 'idle' | 'running' | 'completed' | 'failed';
+    device_code: string | null;
+    verification_url: string | null;
+    output: string;
+    return_code: number | null;
+}
+
+export interface LocalDatasetInfo {
+    name: string;
+    file_count: number;
+    size_bytes: number;
+}
+
+export interface LocalDatasetFile {
+    name: string;
+    content_type: string;
+    file_size_bytes: number;
 }
 
 export interface RunResponseBody extends RunFromApi {
@@ -152,6 +224,13 @@ export interface MetadataFromApi {
     evidence_weight: number | null;
     warmstart_experiments: string | null;
     n_warmstart: number | null;
+    llm_provider?: 'current' | 'copilot' | null;
+    embedding_provider?: 'current' | 'copilot' | null;
+    model?: string | null;
+    belief_model?: string | null;
+    vision_model?: string | null;
+    embedding_model?: string | null;
+    embedding_dimensions?: number | null;
     // Lineage
     parent_run_id?: string | null;
     parent_run_name?: string | null;
@@ -297,15 +376,103 @@ export class RunsApi extends BaseApi {
         });
     }
 
-    async uploadDataset(runId: string, file: File) {
+    async uploadDataset(runId: string, file: File, relativePath?: string) {
         const formData = new FormData();
         formData.append('file', file);
         formData.append('runid', runId);
+        if (relativePath) {
+            formData.append('relative_path', relativePath);
+        }
 
         return this.request<UploadDatasetResponseBody>({
             url: `${RUNS_URL_PREFIX}/upload-dataset`,
             method: 'POST',
             body: formData,
+        });
+    }
+
+    async getRuntimeConfig() {
+        return this.request<RuntimeConfigResponseBody>({
+            url: `${RUNS_URL_PREFIX}/runtime-config`,
+            method: 'GET',
+        });
+    }
+
+    async getProviders() {
+        return this.request<ProvidersResponseBody>({
+            url: `${RUNS_URL_PREFIX}/providers`,
+            method: 'GET',
+        });
+    }
+
+    async startCopilotLogin() {
+        return this.request<CopilotLoginStatus>({
+            url: `${RUNS_URL_PREFIX}/providers/copilot/login`,
+            method: 'POST',
+        });
+    }
+
+    async getCopilotLoginStatus() {
+        return this.request<CopilotLoginStatus>({
+            url: `${RUNS_URL_PREFIX}/providers/copilot/login`,
+            method: 'GET',
+        });
+    }
+
+    async disconnectCopilot() {
+        return this.request<{ message: string }>({
+            url: `${RUNS_URL_PREFIX}/providers/copilot/configuration`,
+            method: 'DELETE',
+        });
+    }
+
+    async getProviderConfiguration() {
+        return this.request<ProviderConfigurationResponseBody>({
+            url: `${RUNS_URL_PREFIX}/providers/configuration`,
+            method: 'GET',
+        });
+    }
+
+    async saveProviderConfiguration(
+        provider: 'openai' | 'vertex',
+        configuration: Record<string, string>
+    ) {
+        return this.request<ProviderConfigurationResponseBody>({
+            url: `${RUNS_URL_PREFIX}/providers/${provider}/configuration`,
+            method: 'PUT',
+            body: configuration,
+        });
+    }
+
+    async deleteProviderConfiguration(provider: 'openai' | 'vertex') {
+        return this.request<ProviderConfigurationResponseBody>({
+            url: `${RUNS_URL_PREFIX}/providers/${provider}/configuration`,
+            method: 'DELETE',
+        });
+    }
+
+    async listLocalDatasets() {
+        return this.request<{ datasets: LocalDatasetInfo[]; catalog_path: string }>({
+            url: `${RUNS_URL_PREFIX}/local-datasets`,
+            method: 'GET',
+        });
+    }
+
+    async browseLocalDatasetFolder() {
+        return this.request<{ path: string | null }>({
+            url: `${RUNS_URL_PREFIX}/local-datasets/browse`,
+            method: 'POST',
+        });
+    }
+
+    async importLocalDataset(
+        runId: string,
+        selection: { dataset_name: string } | { source_path: string }
+    ) {
+        return this.request<{ files: LocalDatasetFile[] }>({
+            url: `${RUNS_URL_PREFIX}/${encodeURIComponent(runId)}/local-datasets/import`,
+            method: 'POST',
+            body: selection,
         });
     }
 

--- a/ui/src/app/components/ClientProviders.tsx
+++ b/ui/src/app/components/ClientProviders.tsx
@@ -7,6 +7,7 @@ import { ViewerCreditsProvider } from '@/contexts/ViewerCreditsContext';
 import { ToastsContextProvider } from '@/contexts/ToastsContext';
 import { ExampleRunsContextProvider } from '@/contexts/ExampleRunsContext';
 import { ViewerRunsContextProvider } from '@/contexts/ViewerRunsContext';
+import { RuntimeConfigProvider } from '@/contexts/RuntimeConfigContext';
 
 interface ClientProvidersProps {
     children: ReactNode;
@@ -14,14 +15,16 @@ interface ClientProvidersProps {
 
 export default function ClientProviders({ children }: ClientProvidersProps) {
     return (
-        <Auth0Provider>
-            <ToastsContextProvider>
-                <ExampleRunsContextProvider>
-                    <ViewerCreditsProvider>
-                        <ViewerRunsContextProvider>{children}</ViewerRunsContextProvider>
-                    </ViewerCreditsProvider>
-                </ExampleRunsContextProvider>
-            </ToastsContextProvider>
-        </Auth0Provider>
+        <RuntimeConfigProvider>
+            <Auth0Provider>
+                <ToastsContextProvider>
+                    <ExampleRunsContextProvider>
+                        <ViewerCreditsProvider>
+                            <ViewerRunsContextProvider>{children}</ViewerRunsContextProvider>
+                        </ViewerCreditsProvider>
+                    </ExampleRunsContextProvider>
+                </ToastsContextProvider>
+            </Auth0Provider>
+        </RuntimeConfigProvider>
     );
 }

--- a/ui/src/app/components/Header.tsx
+++ b/ui/src/app/components/Header.tsx
@@ -9,19 +9,21 @@ import CreditsChip from '@/components/CreditsChip';
 import { AboutButton } from '@/components/AboutButton';
 import { FeedbackButton } from '@/components/FeedbackButton';
 import { useAuth0 } from '@/contexts/Auth0Context';
+import { useRuntimeConfig } from '@/contexts/RuntimeConfigContext';
 import { filterTransientProps } from '@/utils/styledProps';
 import { TEST_ID_BACK_BUTTON, TEST_ID_CREDITS_CHIP } from '@/testIds';
 
 // Smart component — reads hooks, computes props, delegates rendering
 export function Header() {
     const { isAuthenticated } = useAuth0();
+    const { isLocal, isLoading: isRuntimeLoading } = useRuntimeConfig();
     const router = useRouter();
     const pathname = usePathname();
 
     return (
         <HeaderView
             showBackButton={pathname.includes('/shared') && !isAuthenticated}
-            showCredits={isAuthenticated}
+            showCredits={isAuthenticated && !isLocal && !isRuntimeLoading}
             isSharedSamples={pathname.startsWith('/shared/samples')}
             onBack={() => router.push('/runs')}
         />
@@ -90,6 +92,18 @@ const StyledHeader = styled(Box, { shouldForwardProp: filterTransientProps })<{
     padding: ${({ theme }) => theme.spacing(2)};
     padding-top: ${({ theme, $isSharedSamples }) =>
         $isSharedSamples ? theme.spacing(3) : theme.spacing(2)};
+
+    html.autodiscovery-desktop & {
+        padding-top: ${({ theme }) => theme.spacing(5.5)};
+        padding-left: 88px;
+        -webkit-app-region: drag;
+    }
+
+    html.autodiscovery-desktop & button,
+    html.autodiscovery-desktop & a,
+    html.autodiscovery-desktop & [role='button'] {
+        -webkit-app-region: no-drag;
+    }
 
     @media (max-width: 600px) {
         flex-wrap: nowrap;

--- a/ui/src/app/components/MenuLinks.tsx
+++ b/ui/src/app/components/MenuLinks.tsx
@@ -28,7 +28,7 @@ const FEEDBACK_URL =
 /**
  * The link/action list rendered inside the user menu popover.
  */
-export const MenuLinks = () => {
+export const MenuLinks = ({ layout = 'menu' }: { layout?: 'menu' | 'settings' }) => {
     const [isDisclaimerOpen, setIsDisclaimerOpen] = useState(false);
     const [isAttributionOpen, setIsAttributionOpen] = useState(false);
 
@@ -43,50 +43,96 @@ export const MenuLinks = () => {
                     {...mkFeedbackBtnTrackAttrs()}>
                     Leave Feedback
                 </SettingsLink>
+                {layout === 'settings' && (
+                    <>
+                        <SettingsButton
+                            type="button"
+                            aria-haspopup="dialog"
+                            onClick={() => setIsDisclaimerOpen(true)}
+                            data-test-id={TEST_ID_DISCLAIMER_BUTTON}
+                            {...mkDisclaimerBtnTrackAttrs()}>
+                            Disclaimer
+                        </SettingsButton>
+                        <SettingsButton
+                            type="button"
+                            aria-haspopup="dialog"
+                            onClick={() => setIsAttributionOpen(true)}
+                            data-test-id={TEST_ID_ATTRIBUTION_BUTTON}
+                            {...mkAttributionBtnTrackAttrs()}>
+                            Attribution
+                        </SettingsButton>
+                        <SettingsLink
+                            href="https://allenai.org/privacy-policy"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            data-test-id={TEST_ID_PRIVACY_POLICY_LINK}
+                            {...mkPrivacyLinkTrackAttrs()}>
+                            Privacy Policy
+                        </SettingsLink>
+                        <SettingsLink
+                            href="https://allenai.org/terms"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            data-test-id={TEST_ID_TERMS_OF_USE_LINK}
+                            {...mkTosLinkTrackAttrs()}>
+                            Terms of Use
+                        </SettingsLink>
+                        <SettingsLink
+                            href="https://allenai.org/responsible-use"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            data-test-id={TEST_ID_RESPONSIBLE_USE_LINK}
+                            {...mkResponsibleUseLinkTrackAttrs()}>
+                            Responsible Use
+                        </SettingsLink>
+                    </>
+                )}
             </LinksSection>
 
-            <LinksSection>
-                <SettingsButton
-                    type="button"
-                    aria-haspopup="dialog"
-                    onClick={() => setIsDisclaimerOpen(true)}
-                    data-test-id={TEST_ID_DISCLAIMER_BUTTON}
-                    {...mkDisclaimerBtnTrackAttrs()}>
-                    Disclaimer
-                </SettingsButton>
-                <SettingsButton
-                    type="button"
-                    aria-haspopup="dialog"
-                    onClick={() => setIsAttributionOpen(true)}
-                    data-test-id={TEST_ID_ATTRIBUTION_BUTTON}
-                    {...mkAttributionBtnTrackAttrs()}>
-                    Attribution
-                </SettingsButton>
-                <SettingsLink
-                    href="https://allenai.org/privacy-policy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    data-test-id={TEST_ID_PRIVACY_POLICY_LINK}
-                    {...mkPrivacyLinkTrackAttrs()}>
-                    Privacy Policy
-                </SettingsLink>
-                <SettingsLink
-                    href="https://allenai.org/terms"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    data-test-id={TEST_ID_TERMS_OF_USE_LINK}
-                    {...mkTosLinkTrackAttrs()}>
-                    Terms of Use
-                </SettingsLink>
-                <SettingsLink
-                    href="https://allenai.org/responsible-use"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    data-test-id={TEST_ID_RESPONSIBLE_USE_LINK}
-                    {...mkResponsibleUseLinkTrackAttrs()}>
-                    Responsible Use
-                </SettingsLink>
-            </LinksSection>
+            {layout === 'menu' && (
+                <LinksSection>
+                    <SettingsButton
+                        type="button"
+                        aria-haspopup="dialog"
+                        onClick={() => setIsDisclaimerOpen(true)}
+                        data-test-id={TEST_ID_DISCLAIMER_BUTTON}
+                        {...mkDisclaimerBtnTrackAttrs()}>
+                        Disclaimer
+                    </SettingsButton>
+                    <SettingsButton
+                        type="button"
+                        aria-haspopup="dialog"
+                        onClick={() => setIsAttributionOpen(true)}
+                        data-test-id={TEST_ID_ATTRIBUTION_BUTTON}
+                        {...mkAttributionBtnTrackAttrs()}>
+                        Attribution
+                    </SettingsButton>
+                    <SettingsLink
+                        href="https://allenai.org/privacy-policy"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        data-test-id={TEST_ID_PRIVACY_POLICY_LINK}
+                        {...mkPrivacyLinkTrackAttrs()}>
+                        Privacy Policy
+                    </SettingsLink>
+                    <SettingsLink
+                        href="https://allenai.org/terms"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        data-test-id={TEST_ID_TERMS_OF_USE_LINK}
+                        {...mkTosLinkTrackAttrs()}>
+                        Terms of Use
+                    </SettingsLink>
+                    <SettingsLink
+                        href="https://allenai.org/responsible-use"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        data-test-id={TEST_ID_RESPONSIBLE_USE_LINK}
+                        {...mkResponsibleUseLinkTrackAttrs()}>
+                        Responsible Use
+                    </SettingsLink>
+                </LinksSection>
+            )}
 
             <DisclaimerDialog
                 isOpen={isDisclaimerOpen}

--- a/ui/src/app/components/UserMenuFooter.tsx
+++ b/ui/src/app/components/UserMenuFooter.tsx
@@ -3,10 +3,13 @@
 import { Button, Popover, styled } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import LogoutOutlinedIcon from '@mui/icons-material/LogoutOutlined';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import Link from 'next/link';
 import { useState } from 'react';
 
 import { MenuLinks } from './MenuLinks';
 import { useAuth0 } from '@/contexts/Auth0Context';
+import { useRuntimeConfig } from '@/contexts/RuntimeConfigContext';
 import { mkLogoutBtnTrackAttrs, mkUserMenuBtnTrackAttrs } from '@/analytics/run';
 import { TEST_ID_SIGN_OUT_BUTTON, TEST_ID_USER_MENU_BUTTON } from '@/testIds';
 
@@ -15,11 +18,23 @@ import { TEST_ID_SIGN_OUT_BUTTON, TEST_ID_USER_MENU_BUTTON } from '@/testIds';
  */
 export const UserMenuFooter = () => {
     const { user, logout } = useAuth0();
+    const { isLocal } = useRuntimeConfig();
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
     const emailLocal = user?.email?.split('@')[0];
     const displayName = emailLocal || user?.name || 'User';
     const avatarLetter = displayName.charAt(0).toUpperCase() || 'U';
+
+    if (isLocal) {
+        return (
+            <FooterWrapper>
+                <LocalSettingsLink href="/runs/settings" aria-label="Settings">
+                    <SettingsOutlinedIcon />
+                    <UserName>Settings</UserName>
+                </LocalSettingsLink>
+            </FooterWrapper>
+        );
+    }
 
     return (
         <FooterWrapper>
@@ -82,6 +97,21 @@ const UserProfileButton = styled(Button)`
             color: ${({ theme }) => theme.color['cream-40'].rgba.toString()};
             font-size: 1.25rem;
         }
+    }
+`;
+
+const LocalSettingsLink = styled(Link)`
+    align-items: center;
+    background-color: ${({ theme }) => theme.color['cream-4'].rgba.toString()};
+    border-radius: ${({ theme }) => theme.shape.borderRadius}px;
+    color: ${({ theme }) => theme.color['cream-100'].hex};
+    display: flex;
+    gap: ${({ theme }) => theme.spacing(1.5)};
+    padding: ${({ theme }) => theme.spacing(1.5, 2)};
+    text-decoration: none;
+
+    &:hover {
+        background-color: ${({ theme }) => theme.color['cream-10'].rgba.toString()};
     }
 `;
 

--- a/ui/src/app/contexts/RuntimeConfigContext.tsx
+++ b/ui/src/app/contexts/RuntimeConfigContext.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
+
+import { getRunsApi, RuntimeConfigResponseBody } from '@/api/RunsApi';
+
+interface RuntimeConfigState {
+    config: RuntimeConfigResponseBody | null;
+    isLoading: boolean;
+    isLocal: boolean;
+}
+
+const RuntimeConfigContext = createContext<RuntimeConfigState>({
+    config: null,
+    isLoading: true,
+    isLocal: false,
+});
+
+export function RuntimeConfigProvider({ children }: PropsWithChildren) {
+    const [config, setConfig] = useState<RuntimeConfigResponseBody | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        getRunsApi()
+            .getRuntimeConfig()
+            .then(({ data }) => setConfig(data))
+            .catch(() => setConfig(null))
+            .finally(() => setIsLoading(false));
+    }, []);
+
+    const value = useMemo(
+        () => ({
+            config,
+            isLoading,
+            isLocal: config?.deployment_mode === 'local',
+        }),
+        [config, isLoading]
+    );
+
+    return <RuntimeConfigContext.Provider value={value}>{children}</RuntimeConfigContext.Provider>;
+}
+
+export function useRuntimeConfig(): RuntimeConfigState {
+    return useContext(RuntimeConfigContext);
+}

--- a/ui/src/app/contexts/ViewerCreditsContext.tsx
+++ b/ui/src/app/contexts/ViewerCreditsContext.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react';
 
 import { useAuth0 } from '@/contexts/Auth0Context';
+import { useRuntimeConfig } from '@/contexts/RuntimeConfigContext';
 import { getUserApi, ViewerCreditsFromApi } from '@/api/UserApi';
 
 export interface ViewerCreditsState {
@@ -61,12 +62,13 @@ export const ViewerCreditsProvider = ({ children }: ViewerCreditsProviderProps) 
     const hasLoadedOnce = useRef(false);
 
     const { isAuthenticated } = useAuth0();
+    const { isLocal, isLoading: isRuntimeLoading } = useRuntimeConfig();
 
     const startPolling = useCallback(() => setIsPolling(true), []);
     const stopPolling = useCallback(() => setIsPolling(false), []);
 
     const updateViewerCredits = useCallback(async () => {
-        if (!isAuthenticated) {
+        if (!isAuthenticated || isLocal || isRuntimeLoading) {
             return;
         }
         setIsLoading(true);
@@ -84,26 +86,26 @@ export const ViewerCreditsProvider = ({ children }: ViewerCreditsProviderProps) 
         } finally {
             setIsLoading(false);
         }
-    }, [isAuthenticated, lastError]);
+    }, [isAuthenticated, isLocal, isRuntimeLoading, lastError]);
 
     useEffect(() => {
-        if (isAuthenticated) {
+        if (isAuthenticated && !isLocal && !isRuntimeLoading) {
             setIsPolling(true);
         } else {
             setIsPolling(false);
-            setIsLoadingInitial(true);
+            setIsLoadingInitial(!isLocal);
             hasLoadedOnce.current = false;
         }
-    }, [isAuthenticated]);
+    }, [isAuthenticated, isLocal, isRuntimeLoading]);
 
     useEffect(() => {
-        if (!isAuthenticated || !isPolling) {
+        if (!isAuthenticated || isLocal || isRuntimeLoading || !isPolling) {
             return;
         }
         updateViewerCredits();
         const interval = setInterval(updateViewerCredits, REFRESH_INTERVAL_MS);
         return () => clearInterval(interval);
-    }, [isAuthenticated, isPolling, updateViewerCredits]);
+    }, [isAuthenticated, isLocal, isRuntimeLoading, isPolling, updateViewerCredits]);
 
     const memoizedState = useMemo<ViewerCreditsState>(
         () => ({

--- a/ui/src/app/runs/components/DatasetUpload.tsx
+++ b/ui/src/app/runs/components/DatasetUpload.tsx
@@ -15,6 +15,7 @@ import {
     Collapse,
 } from '@mui/material';
 import CloudUploadOutlinedIcon from '@mui/icons-material/CloudUploadOutlined';
+import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
 import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import CloseIcon from '@mui/icons-material/Close';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
@@ -23,7 +24,7 @@ import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import prettyBytes from 'pretty-bytes';
 import prettyMs from 'pretty-ms';
 
-import { FileUploadState, UploadStatus } from '@/runs/hooks/useRunSetup';
+import { FileUploadState, getLocalFilePath, UploadStatus } from '@/runs/hooks/useRunSetup';
 import { getFriendlyMimeType, getMimeType } from '@/utils/mimeType';
 
 export interface Dataset {
@@ -72,6 +73,7 @@ interface DatasetUploadProps {
     onRetryUpload: (index: number) => void;
     disabled?: boolean;
     error?: string;
+    localMode?: boolean;
 }
 
 /**
@@ -93,8 +95,10 @@ export default function DatasetUpload({
     onRetryUpload,
     disabled = false,
     error,
+    localMode = false,
 }: DatasetUploadProps) {
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const folderInputRef = useRef<HTMLInputElement>(null);
     const [isDragging, setIsDragging] = useState(false);
 
     const handleDragEnter = (e: DragEvent<HTMLDivElement>) => {
@@ -129,7 +133,8 @@ export default function DatasetUpload({
         }
     };
 
-    const handleClick = () => {
+    const handleClick = (e?: React.MouseEvent) => {
+        e?.stopPropagation();
         if (!disabled) {
             fileInputRef.current?.click();
         }
@@ -142,6 +147,13 @@ export default function DatasetUpload({
         }
     };
 
+    const handleFolderClick = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (!disabled) {
+            folderInputRef.current?.click();
+        }
+    };
+
     return (
         <Box>
             <input
@@ -151,6 +163,19 @@ export default function DatasetUpload({
                 style={{ display: 'none' }}
                 multiple
             />
+            {localMode && (
+                <input
+                    ref={folderInputRef}
+                    type="file"
+                    onChange={handleFileInputChange}
+                    style={{ display: 'none' }}
+                    multiple
+                    {...({
+                        webkitdirectory: '',
+                        directory: '',
+                    } as React.InputHTMLAttributes<HTMLInputElement>)}
+                />
+            )}
 
             <DropZone
                 onClick={handleClick}
@@ -163,13 +188,35 @@ export default function DatasetUpload({
                 hasError={!!error}>
                 <CloudUploadOutlinedIcon />
                 <Typography variant="body1" gutterBottom>
-                    Drop files here or browse
+                    {localMode
+                        ? 'Drop files here or choose files from this computer'
+                        : 'Drop files here or browse'}
                 </Typography>
-                <Typography variant="caption" sx={{ mt: 1, opacity: 0.6 }}>
-                    {maxFileSize
-                        ? `Max ${maxFileSize} per file`
-                        : 'Max 10GB per file, 20GB total session limit'}
-                </Typography>
+                {localMode ? (
+                    <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+                        <Button variant="outlined" size="small" onClick={handleClick}>
+                            Choose files
+                        </Button>
+                        <Button
+                            variant="outlined"
+                            size="small"
+                            startIcon={<FolderOpenOutlinedIcon />}
+                            onClick={handleFolderClick}>
+                            Choose folder
+                        </Button>
+                    </Stack>
+                ) : (
+                    <Typography variant="caption" sx={{ mt: 1, opacity: 0.6 }}>
+                        {maxFileSize
+                            ? `Max ${maxFileSize} per file`
+                            : 'Max 10GB per file, 20GB total session limit'}
+                    </Typography>
+                )}
+                {localMode && (
+                    <Typography variant="caption" sx={{ mt: 1, opacity: 0.7 }}>
+                        Selected files are copied into this run&apos;s local data folder.
+                    </Typography>
+                )}
             </DropZone>
 
             {fileUploads.length > 0 && (
@@ -183,7 +230,11 @@ export default function DatasetUpload({
                                 <File>
                                     <FileHeader>
                                         <DescriptionOutlinedIcon />
-                                        <FileHeaderFilename>{upload.file.name}</FileHeaderFilename>
+                                        <FileHeaderFilename>
+                                            {localMode
+                                                ? getLocalFilePath(upload.file)
+                                                : upload.file.name}
+                                        </FileHeaderFilename>
                                         <FileHeaderFileMeta>
                                             {friendlyType} • {prettyBytes(upload.totalBytes)}
                                         </FileHeaderFileMeta>

--- a/ui/src/app/runs/components/ExperimentDetails.tsx
+++ b/ui/src/app/runs/components/ExperimentDetails.tsx
@@ -193,6 +193,11 @@ const TitleWrapper = styled('div')`
     row-gap: 12px;
     padding: 24px;
     border-bottom: 1px solid ${({ theme }) => theme.color['cream-10'].rgba.toString()};
+    background-color: rgba(22, 54, 56, 0.96);
+    backdrop-filter: blur(8px);
+    position: sticky;
+    top: 0;
+    z-index: 2;
 `;
 
 const ContentWrapper = styled(Stack)`

--- a/ui/src/app/runs/components/ExperimentGraph.tsx
+++ b/ui/src/app/runs/components/ExperimentGraph.tsx
@@ -689,7 +689,9 @@ export const ExperimentGraph = memo(function ExperimentGraph({
         return (
             <GraphContainer ref={containerRef} data-test-id={TEST_ID_EXPERIMENT_GRAPH}>
                 <EmptyState>
-                    <Typography variant="body2" color="textSecondary">
+                    <Typography
+                        variant="body2"
+                        sx={(theme) => ({ color: theme.color['cream-80'].rgba.toString() })}>
                         No experiments to display
                     </Typography>
                 </EmptyState>

--- a/ui/src/app/runs/components/LocalDatasetPicker.tsx
+++ b/ui/src/app/runs/components/LocalDatasetPicker.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState } from 'react';
+import {
+    Alert,
+    Box,
+    Button,
+    FormHelperText,
+    InputAdornment,
+    MenuItem,
+    Select,
+    Stack,
+    TextField,
+    Typography,
+    styled,
+} from '@mui/material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
+import prettyBytes from 'pretty-bytes';
+
+import { LocalDatasetInfo } from '@/api/RunsApi';
+
+const OTHER_DATASET = '__other_dataset__';
+
+interface LocalDatasetPickerProps {
+    datasets: LocalDatasetInfo[];
+    selectedDataset: string;
+    folderPath: string;
+    activeDataset: string;
+    selectedFileCount: number;
+    loading: boolean;
+    error: string | null;
+    disabled: boolean;
+    onDatasetChange: (value: string) => void;
+    onFolderPathChange: (value: string) => void;
+    onBrowse: () => void;
+    onUseFolderPath: () => void;
+}
+
+export default function LocalDatasetPicker({
+    datasets,
+    selectedDataset,
+    folderPath,
+    activeDataset,
+    selectedFileCount,
+    loading,
+    error,
+    disabled,
+    onDatasetChange,
+    onFolderPathChange,
+    onBrowse,
+    onUseFolderPath,
+}: LocalDatasetPickerProps) {
+    const [showOtherDataset, setShowOtherDataset] = useState(false);
+
+    const handleDatasetChange = (value: string) => {
+        if (value === OTHER_DATASET) {
+            setShowOtherDataset(true);
+            onBrowse();
+            return;
+        }
+        setShowOtherDataset(false);
+        onDatasetChange(value);
+    };
+
+    return (
+        <Stack spacing={2}>
+            <Select
+                displayEmpty
+                fullWidth
+                value={showOtherDataset ? OTHER_DATASET : selectedDataset}
+                onChange={(event) => handleDatasetChange(event.target.value)}
+                disabled={disabled || loading}>
+                <MenuItem value="" disabled>
+                    Choose a dataset
+                </MenuItem>
+                {datasets.map((dataset) => (
+                    <MenuItem key={dataset.name} value={dataset.name}>
+                        {dataset.name} ({dataset.file_count} files,{' '}
+                        {prettyBytes(dataset.size_bytes)})
+                    </MenuItem>
+                ))}
+                <MenuItem value={OTHER_DATASET}>Choose another dataset…</MenuItem>
+            </Select>
+
+            {showOtherDataset && (
+                <Box>
+                    <DatasetHelperText>
+                        Enter a dataset path and press Enter, or choose a dataset with Browse.
+                    </DatasetHelperText>
+                    <TextField
+                        fullWidth
+                        value={folderPath}
+                        onChange={(event) => onFolderPathChange(event.target.value)}
+                        onKeyDown={(event) => {
+                            if (event.key === 'Enter' && folderPath.trim()) {
+                                event.preventDefault();
+                                onUseFolderPath();
+                            }
+                        }}
+                        placeholder="~/Data/my-dataset"
+                        disabled={disabled || loading}
+                        InputProps={{
+                            endAdornment: (
+                                <InputAdornment position="end">
+                                    <Button
+                                        startIcon={<FolderOpenOutlinedIcon />}
+                                        onClick={onBrowse}
+                                        disabled={disabled || loading}
+                                        sx={(theme) => ({ color: theme.color['green-100'].hex })}>
+                                        Browse…
+                                    </Button>
+                                </InputAdornment>
+                            ),
+                        }}
+                    />
+                </Box>
+            )}
+
+            {activeDataset && (
+                <SelectedDatasetSummary direction="row" spacing={1} alignItems="center">
+                    <CheckCircleOutlineIcon color="success" fontSize="small" />
+                    <Typography variant="body2">
+                        Using <strong>{activeDataset}</strong> ({selectedFileCount} files)
+                    </Typography>
+                </SelectedDatasetSummary>
+            )}
+            {error && <Alert severity="error">{error}</Alert>}
+        </Stack>
+    );
+}
+
+const DatasetHelperText = styled(FormHelperText)(({ theme }) => ({
+    color: theme.color['cream-80'].rgba.toString(),
+    margin: theme.spacing(0.5, 0, 1, 0),
+}));
+
+const SelectedDatasetSummary = styled(Stack)(({ theme }) => ({
+    color: theme.color['cream-100'].hex,
+}));

--- a/ui/src/app/runs/components/RunSetup.tsx
+++ b/ui/src/app/runs/components/RunSetup.tsx
@@ -41,6 +41,8 @@ import DatasetUpload, {
 } from '@/runs/components/DatasetUpload';
 import { mkExpandAdvancedSettingsTrackAttrs, mkSubmitRunBtnTrackAttrs } from '@/analytics/runSetup';
 import { PRELOADED_DATASETS } from '@/runs/utils/preloadedDatasets';
+import { estimateLocalRunCost } from '@/runs/utils/localCostEstimate';
+import LocalDatasetPicker from '@/runs/components/LocalDatasetPicker';
 
 const DEBOUNCE_SAVE_MS = 3000;
 
@@ -61,6 +63,8 @@ interface RunSetupProps {
 export default function RunSetup({ runid, onSubmitSuccess }: RunSetupProps) {
     const {
         settings,
+        providers,
+        isLocal,
         creditsAvailable,
         fileUploads,
         maxFileSize,
@@ -81,10 +85,62 @@ export default function RunSetup({ runid, onSubmitSuccess }: RunSetupProps) {
         selectedDatasetIds,
         togglePreloadedDataset,
         updatePreloadedDescription,
+        localDatasets,
+        localCatalogPath,
+        selectedLocalDataset,
+        localFolderPath,
+        setLocalFolderPath,
+        activeLocalDataset,
+        isSelectingLocalDataset,
+        localDatasetError,
+        importLocalDataset,
+        browseLocalDatasetFolder,
+        importLocalFolderPath,
     } = useRunSetup({ runid, onSubmitSuccess, debounceSaveMs: DEBOUNCE_SAVE_MS });
 
     const isFormDisabled = isSubmitting || isLoading;
     const datasetErrors = fieldErrors.datasets;
+    const selectedProvider = providers.find((provider) => provider.id === settings.llmProvider);
+    const providerError =
+        fieldErrors.provider ||
+        (selectedProvider && selectedProvider.status !== 'ready'
+            ? selectedProvider.remediation || 'Provider is not ready.'
+            : undefined);
+    const selectedEmbeddingProvider = providers.find(
+        (provider) => provider.id === settings.embeddingProvider
+    );
+    const embeddingProviderError =
+        fieldErrors.embeddingProvider ||
+        (selectedEmbeddingProvider && !selectedEmbeddingProvider.embedding_ready
+            ? selectedEmbeddingProvider.remediation || 'Embedding provider is not ready.'
+            : undefined);
+    const selectedAgentModel = selectedProvider?.models.find(
+        (model) => model.id === settings.model
+    );
+    const selectedBeliefModel = selectedProvider?.models.find(
+        (model) => model.id === settings.beliefModel
+    );
+    const toEstimatePrice = (pricing?: {
+        input_per_million_usd: number;
+        output_per_million_usd: number;
+    }) =>
+        pricing
+            ? {
+                  inputPerMillion: pricing.input_per_million_usd,
+                  outputPerMillion: pricing.output_per_million_usd,
+              }
+            : undefined;
+    const localEstimate = estimateLocalRunCost(
+        settings.nExperiments,
+        settings.model,
+        settings.beliefModel,
+        toEstimatePrice(selectedAgentModel?.pricing),
+        toEstimatePrice(selectedBeliefModel?.pricing)
+    );
+    const estimatedTokens =
+        localEstimate.totalTokens >= 1_000_000
+            ? `${(localEstimate.totalTokens / 1_000_000).toFixed(1)}M`
+            : `${Math.round(localEstimate.totalTokens / 1_000)}K`;
 
     if (isLoading) {
         return (
@@ -104,9 +160,9 @@ export default function RunSetup({ runid, onSubmitSuccess }: RunSetupProps) {
         <Box sx={{ maxWidth: 'md', mx: 'auto', p: 3 }}>
             <SectionHeader>
                 <SectionHeaderTitle>Create a new discovery session</SectionHeaderTitle>
-                Define your context and upload source files. AutoDiscovery will use your data to
-                generate hypotheses, run experiments to statistically refute or accept them and
-                reveal surprising insights.
+                {isLocal
+                    ? 'Define your context and select a dataset. AutoDiscovery will use your data to generate hypotheses, run experiments to statistically refute or accept them and reveal surprising insights.'
+                    : 'Define your context and upload source files. AutoDiscovery will use your data to generate hypotheses, run experiments to statistically refute or accept them and reveal surprising insights.'}
             </SectionHeader>
 
             <ConfigurationBox className={settings.parentRunId ? 'forked' : ''}>
@@ -185,14 +241,18 @@ export default function RunSetup({ runid, onSubmitSuccess }: RunSetupProps) {
                     />
                 </FormControl>
                 <FormControl fullWidth>
-                    <StyledFormLabel error={!!datasetErrors}>Source files</StyledFormLabel>
+                    <StyledFormLabel error={!!datasetErrors}>
+                        {isLocal ? 'Dataset' : 'Source files'}
+                    </StyledFormLabel>
                     <HelperText>
-                        {hasAi1Permission
-                            ? 'Select preloaded datasets and/or upload source files.'
-                            : 'Upload source files for your discovery session.'}
+                        {isLocal
+                            ? `Choose from the datasets in ${localCatalogPath || 'your local data folder'}, or choose another dataset on this computer.`
+                            : hasAi1Permission
+                              ? 'Select preloaded datasets and/or upload source files.'
+                              : 'Upload source files for your discovery session.'}
                     </HelperText>
 
-                    {hasAi1Permission && (
+                    {!isLocal && hasAi1Permission && (
                         <>
                             <Box sx={{ display: 'flex', gap: 1, mb: 1, width: '100%' }}>
                                 {PRELOADED_DATASETS.map((dataset) => (
@@ -274,17 +334,34 @@ export default function RunSetup({ runid, onSubmitSuccess }: RunSetupProps) {
                             </Box>
                         </>
                     )}
-                    <DatasetUpload
-                        fileUploads={fileUploads}
-                        maxFileSize={maxFileSize}
-                        onFileSelect={handleFileSelect}
-                        onRemoveFileUpload={handleRemoveFileUpload}
-                        onDescriptionChange={handleFileDescriptionChange}
-                        onCancelUpload={cancelUpload}
-                        onRetryUpload={retryUpload}
-                        disabled={isFormDisabled}
-                        error={datasetErrors}
-                    />
+                    {isLocal ? (
+                        <LocalDatasetPicker
+                            datasets={localDatasets}
+                            selectedDataset={selectedLocalDataset}
+                            folderPath={localFolderPath}
+                            activeDataset={activeLocalDataset}
+                            selectedFileCount={fileUploads.length}
+                            loading={isSelectingLocalDataset}
+                            error={localDatasetError}
+                            disabled={isFormDisabled}
+                            onDatasetChange={importLocalDataset}
+                            onFolderPathChange={setLocalFolderPath}
+                            onBrowse={browseLocalDatasetFolder}
+                            onUseFolderPath={importLocalFolderPath}
+                        />
+                    ) : (
+                        <DatasetUpload
+                            fileUploads={fileUploads}
+                            maxFileSize={maxFileSize}
+                            onFileSelect={handleFileSelect}
+                            onRemoveFileUpload={handleRemoveFileUpload}
+                            onDescriptionChange={handleFileDescriptionChange}
+                            onCancelUpload={cancelUpload}
+                            onRetryUpload={retryUpload}
+                            disabled={isFormDisabled}
+                            error={datasetErrors}
+                        />
+                    )}
                 </FormControl>
             </ConfigurationBox>
 
@@ -298,11 +375,9 @@ export default function RunSetup({ runid, onSubmitSuccess }: RunSetupProps) {
                         Experiment budget
                     </StyledFormLabel>
                     <HelperText>
-                        Set the maximum number of experiments to generate (
-                        <strong>1 Credit = 1 Experiment</strong>) during the exploration. If this is
-                        your first session, we recommend starting with a small budget ({'<'}10
-                        experiments) to learn how the system works. Once you're familiar with the
-                        output, you can confidently scale up to 50–100 experiments per session.
+                        {isLocal
+                            ? 'Set the maximum number of experiments to run on this computer. Start with 2–5 while validating a dataset and model combination.'
+                            : 'Set the maximum number of experiments to generate during the exploration.'}
                     </HelperText>
                     <TextField
                         type="number"
@@ -313,9 +388,25 @@ export default function RunSetup({ runid, onSubmitSuccess }: RunSetupProps) {
                         error={!!fieldErrors.nExperiments}
                         fullWidth
                     />
-                    <RemainingCreditsChip
-                        label={`Your credits after this run: ${creditsAvailable - settings.nExperiments}`}
-                    />
+                    {isLocal ? (
+                        <LocalEstimateRow>
+                            <span>{localEstimate.experiments} experiments</span>
+                            <span>~{estimatedTokens} model tokens</span>
+                            <strong>
+                                ~${localEstimate.lowUSD.toFixed(2)}–$
+                                {localEstimate.highUSD.toFixed(2)} estimated usage
+                            </strong>
+                            <small>
+                                {localEstimate.livePricing
+                                    ? 'Live Copilot token rates; range reflects observed run variability.'
+                                    : 'Bundled model rate card; range reflects observed run variability.'}
+                            </small>
+                        </LocalEstimateRow>
+                    ) : (
+                        <RemainingCreditsChip
+                            label={`Your credits after this run: ${creditsAvailable - settings.nExperiments}`}
+                        />
+                    )}
                 </FormControl>
                 <FormControl fullWidth>
                     <StyledFormLabel>
@@ -347,6 +438,137 @@ export default function RunSetup({ runid, onSubmitSuccess }: RunSetupProps) {
                         {...mkExpandAdvancedSettingsTrackAttrs({ runId: runid })}>
                         <Typography component="span">Advanced settings</Typography>
                     </AccordionSummary>
+
+                    {!isLocal && (
+                        <FormControl fullWidth error={!!providerError}>
+                            <StyledFormLabel error={!!providerError}>
+                                Model provider
+                            </StyledFormLabel>
+                            <HelperText>
+                                Provider used for agents, belief sampling, vision, and merge
+                                decisions.
+                            </HelperText>
+                            <Select
+                                value={settings.llmProvider}
+                                onChange={(e) => {
+                                    const provider = e.target.value as 'current' | 'copilot';
+                                    const selected = providers.find((item) => item.id === provider);
+                                    const nextModel =
+                                        (provider === 'copilot'
+                                            ? selected?.models.find(
+                                                  (model) => model.id === 'claude-sonnet-4.6'
+                                              )?.id
+                                            : selected?.models[0]?.id) || settings.model;
+                                    updateSettings('llmProvider', provider);
+                                    updateSettings('model', nextModel);
+                                    updateSettings('beliefModel', nextModel);
+                                    updateSettings('visionModel', nextModel);
+                                    debouncedSaveMetadata();
+                                }}>
+                                {providers.map((provider) => (
+                                    <MenuItem
+                                        key={provider.id}
+                                        value={provider.id}
+                                        disabled={provider.status !== 'ready'}>
+                                        {provider.name}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                            {providerError ? (
+                                <FormHelperText error>{providerError}</FormHelperText>
+                            ) : (
+                                <FormHelperText>
+                                    {providers.find(
+                                        (provider) => provider.id === settings.llmProvider
+                                    )?.message || 'Choose where model requests are sent.'}
+                                </FormHelperText>
+                            )}
+                        </FormControl>
+                    )}
+
+                    <FormControl fullWidth>
+                        <ModelFormLabel>Agent model</ModelFormLabel>
+                        <Select
+                            value={settings.model}
+                            onChange={(e) => {
+                                updateSettings('model', e.target.value);
+                                updateSettings('visionModel', e.target.value);
+                                debouncedSaveMetadata();
+                            }}>
+                            {(
+                                providers.find((provider) => provider.id === settings.llmProvider)
+                                    ?.models || []
+                            ).map((model) => (
+                                <MenuItem key={model.id} value={model.id}>
+                                    {model.name}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+
+                    <FormControl fullWidth>
+                        <ModelFormLabel>Belief model</ModelFormLabel>
+                        <Select
+                            value={settings.beliefModel}
+                            onChange={(e) => {
+                                updateSettings('beliefModel', e.target.value);
+                                debouncedSaveMetadata();
+                            }}>
+                            {(
+                                providers.find((provider) => provider.id === settings.llmProvider)
+                                    ?.models || []
+                            ).map((model) => (
+                                <MenuItem key={model.id} value={model.id}>
+                                    {model.name}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+
+                    {isLocal ? (
+                        <FormControl fullWidth>
+                            <ModelFormLabel>Embedding model</ModelFormLabel>
+                            <TextField value="text-embedding-3-small (1536 dimensions)" disabled />
+                            <HelperText>
+                                Used to nominate similar hypotheses for deduplication.
+                            </HelperText>
+                        </FormControl>
+                    ) : (
+                        <FormControl fullWidth error={!!embeddingProviderError}>
+                            <StyledFormLabel>Embedding provider</StyledFormLabel>
+                            <Select
+                                value={settings.embeddingProvider}
+                                onChange={(e) => {
+                                    const provider = e.target.value as 'current' | 'copilot';
+                                    updateSettings('embeddingProvider', provider);
+                                    updateSettings(
+                                        'embeddingModel',
+                                        provider === 'copilot'
+                                            ? 'text-embedding-3-small'
+                                            : 'text-embedding-3-large'
+                                    );
+                                    updateSettings(
+                                        'embeddingDimensions',
+                                        provider === 'copilot' ? 1536 : 3072
+                                    );
+                                    debouncedSaveMetadata();
+                                }}>
+                                {providers.map((provider) => (
+                                    <MenuItem
+                                        key={provider.id}
+                                        value={provider.id}
+                                        disabled={!provider.embedding_ready}>
+                                        {provider.id === 'current'
+                                            ? 'OpenAI embeddings (API key)'
+                                            : provider.name}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                            {embeddingProviderError && (
+                                <FormHelperText error>{embeddingProviderError}</FormHelperText>
+                            )}
+                        </FormControl>
+                    )}
 
                     <FormControl fullWidth>
                         <StyledFormLabel>Exploration weight</StyledFormLabel>
@@ -572,6 +794,10 @@ const StyledFormLabel = styled(FormLabel)(({ theme }) => ({
     },
 }));
 
+const ModelFormLabel = styled(StyledFormLabel)(({ theme }) => ({
+    marginBottom: theme.spacing(1),
+}));
+
 const HelperText = styled(FormHelperText)(({ theme }) => ({
     color: theme.color['cream-80'].rgba.toString(),
     margin: theme.spacing(0.5, 0, 1, 0),
@@ -680,6 +906,24 @@ const RemainingCreditsChip = styled(Chip)(({ theme }) => ({
     borderRadius: theme.shape.borderRadius + 'px',
     color: theme.color['cream-100'].hex,
     marginTop: theme.spacing(1),
+}));
+
+const LocalEstimateRow = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(0.75, 2),
+    marginTop: theme.spacing(1),
+    color: theme.color['cream-80'].rgba.toString(),
+    fontSize: '0.875rem',
+    lineHeight: 1.5,
+    '& span, & strong': {
+        minWidth: 0,
+    },
+    '& small': {
+        flexBasis: '100%',
+        color: theme.color['cream-60'].rgba.toString(),
+        fontSize: '0.875rem',
+    },
 }));
 
 const SurpriseSlider = styled(Slider)(({ theme }) => ({

--- a/ui/src/app/runs/components/RunSummary.tsx
+++ b/ui/src/app/runs/components/RunSummary.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { Run, RunStatus } from '@/types/Run';
 import { RunPills } from '@/runs/components/RunPills';
 import { useAuth0 } from '@/contexts/Auth0Context';
+import { useRuntimeConfig } from '@/contexts/RuntimeConfigContext';
 
 export type RunSummaryProps = {
     run: Run;
@@ -13,6 +14,7 @@ export type RunSummaryProps = {
 
 export const RunSummary = ({ run }: RunSummaryProps) => {
     const { user: authUser } = useAuth0();
+    const { isLocal } = useRuntimeConfig();
     const { id, userid, name, description } = run;
     const status = run.details?.status ?? RunStatus.UNKNOWN;
     const shortDescription = description?.includes('.')
@@ -20,7 +22,7 @@ export const RunSummary = ({ run }: RunSummaryProps) => {
         : description;
 
     // If the run belongs to a different user, use the /shared route
-    const isSharedRun = authUser?.sub !== userid;
+    const isSharedRun = !isLocal && authUser?.sub !== userid;
     const href = isSharedRun ? `/shared/${userid}/${id}` : `/runs/${id}`;
 
     return (

--- a/ui/src/app/runs/components/RunView.tsx
+++ b/ui/src/app/runs/components/RunView.tsx
@@ -39,6 +39,7 @@ import { ExperimentGraph } from '@/runs/components/ExperimentGraph';
 import { ExperimentsTable } from '@/runs/components/ExperimentsTable';
 import { ExperimentDetails } from '@/runs/components/ExperimentDetails';
 import { RunExperimentsProvider, useRunExperiments } from '@/contexts/RunExperimentsContext';
+import { useRuntimeConfig } from '@/contexts/RuntimeConfigContext';
 import { TopSurprisalsList } from '@/runs/components/TopSurprisalsList';
 import { useSearchValue, useURLSearchParams } from '@/contexts/URLSearchParamsContext';
 import { StatusChip } from '@/runs/components/StatusChip';
@@ -69,6 +70,7 @@ import {
     ExperimentPanelBackdrop,
     LargeScreenAction,
     PanelDragHandle,
+    ExperimentActionButton,
     usePanelWidthPx,
 } from '@/runs/components/RunViewPanels';
 import { useViewerRuns } from '@/contexts/ViewerRunsContext';
@@ -282,6 +284,8 @@ function RunViewContent({
     const isDragEnabled = useMediaQuery('(min-width:1200px)');
     const showCompactActions = useMediaQuery('(max-width:799px)');
     const { addSuccessToast, addErrorToast } = useToasts();
+    const { isLocal } = useRuntimeConfig();
+    const canShare = !isLocal;
 
     const datasetExpired = isDatasetExpired(run.datasetExpiresAt);
     const datasetExpiryLabel = getDatasetExpiryLabel(run.datasetExpiresAt);
@@ -325,6 +329,15 @@ function RunViewContent({
             setIsClosingPanel(false);
         }, 300);
     }, [selectExperiment]);
+
+    useEffect(() => {
+        if (!selectedExperiment) return;
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') handleClosePanel();
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [selectedExperiment, handleClosePanel]);
 
     const onShareClick = useCallback(
         async (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -442,6 +455,10 @@ function RunViewContent({
         run.details.status === 'FAILED' ||
         run.details.status === 'ERROR' ||
         run.details.status === 'CANCELLED';
+    const runningCostLabel =
+        run.details.status === 'RUNNING' && run.estimatedCostUSD != null
+            ? `Running · est. $${run.estimatedCostUSD.toFixed(2)}`
+            : toSentenceCase(run.details.status);
 
     return (
         <Container>
@@ -516,20 +533,22 @@ function RunViewContent({
                                                 anchorEl={overflowAnchorEl}
                                                 open={!!overflowAnchorEl}
                                                 onClose={() => setOverflowAnchorEl(null)}>
-                                                <MenuItem
-                                                    onClick={(
-                                                        e: React.MouseEvent<HTMLLIElement>
-                                                    ) => {
-                                                        setOverflowAnchorEl(null);
-                                                        onShareClick(
-                                                            e as unknown as React.MouseEvent<HTMLButtonElement>
-                                                        );
-                                                    }}>
-                                                    <ListItemIcon>
-                                                        <ShareOutlinedIcon fontSize="small" />
-                                                    </ListItemIcon>
-                                                    <ListItemText>Share session</ListItemText>
-                                                </MenuItem>
+                                                {canShare && (
+                                                    <MenuItem
+                                                        onClick={(
+                                                            e: React.MouseEvent<HTMLLIElement>
+                                                        ) => {
+                                                            setOverflowAnchorEl(null);
+                                                            onShareClick(
+                                                                e as unknown as React.MouseEvent<HTMLButtonElement>
+                                                            );
+                                                        }}>
+                                                        <ListItemIcon>
+                                                            <ShareOutlinedIcon fontSize="small" />
+                                                        </ListItemIcon>
+                                                        <ListItemText>Share session</ListItemText>
+                                                    </MenuItem>
+                                                )}
                                                 <MenuItem
                                                     disabled={experiments.length === 0}
                                                     onClick={(e) => {
@@ -660,17 +679,19 @@ function RunViewContent({
                                                     JSON
                                                 </MenuItem>
                                             </DownloadMenu>
-                                            <Tooltip title="Share session" placement="bottom">
-                                                <ExpandingActionButton
-                                                    onClick={onShareClick}
-                                                    size="small"
-                                                    variant="outlined">
-                                                    <ShareOutlinedIcon fontSize="small" />
-                                                    <ButtonLabel className="button-label">
-                                                        Share session
-                                                    </ButtonLabel>
-                                                </ExpandingActionButton>
-                                            </Tooltip>
+                                            {canShare && (
+                                                <Tooltip title="Share session" placement="bottom">
+                                                    <ExpandingActionButton
+                                                        onClick={onShareClick}
+                                                        size="small"
+                                                        variant="outlined">
+                                                        <ShareOutlinedIcon fontSize="small" />
+                                                        <ButtonLabel className="button-label">
+                                                            Share session
+                                                        </ButtonLabel>
+                                                    </ExpandingActionButton>
+                                                </Tooltip>
+                                            )}
                                         </>
                                     )}
                                 </RunHeaderActions>
@@ -708,11 +729,21 @@ function RunViewContent({
                     </RunHeader>
                     <RunHeaderSubtitle>
                         <StyledListItem>
-                            <StatusChip
-                                label={toSentenceCase(run.details.status)}
-                                size="small"
-                                $status={run.details.status}
-                            />
+                            {run.details.status === 'RUNNING' && run.estimatedCostUSD != null ? (
+                                <Tooltip title="High-end API-equivalent estimate based on actual token usage. Your Copilot charge may be lower or included in your plan.">
+                                    <StatusChip
+                                        label={runningCostLabel}
+                                        size="small"
+                                        $status={run.details.status}
+                                    />
+                                </Tooltip>
+                            ) : (
+                                <StatusChip
+                                    label={runningCostLabel}
+                                    size="small"
+                                    $status={run.details.status}
+                                />
+                            )}
                         </StyledListItem>
                         <StyledListItem>
                             {getRunStatusString(run.details, experiments)}
@@ -804,17 +835,30 @@ function RunViewContent({
                                 datasetExpired={datasetExpired}
                                 actions={
                                     <>
-                                        <Tooltip title="Share experiment" placement="bottom">
-                                            <ExpandingActionButton
-                                                onClick={onShareExperimentClick}
-                                                size="small"
-                                                variant="outlined">
-                                                <ShareOutlinedIcon fontSize="small" />
-                                                <ButtonLabel className="button-label">
-                                                    Share experiment
-                                                </ButtonLabel>
-                                            </ExpandingActionButton>
+                                        <Tooltip title="Close" placement="bottom">
+                                            <ExperimentActionButton
+                                                aria-label="Close experiment details"
+                                                onClick={handleClosePanel}
+                                                data-test-id={TEST_ID_EXPERIMENT_DETAILS_CLOSE}
+                                                {...mkCloseExperimentDetailsPanelAttrs({
+                                                    runId: run.id,
+                                                })}>
+                                                <CloseIcon fontSize="small" />
+                                            </ExperimentActionButton>
                                         </Tooltip>
+                                        {canShare && (
+                                            <Tooltip title="Share experiment" placement="bottom">
+                                                <ExpandingActionButton
+                                                    onClick={onShareExperimentClick}
+                                                    size="small"
+                                                    variant="outlined">
+                                                    <ShareOutlinedIcon fontSize="small" />
+                                                    <ButtonLabel className="button-label">
+                                                        Share experiment
+                                                    </ButtonLabel>
+                                                </ExpandingActionButton>
+                                            </Tooltip>
+                                        )}
                                         <LargeScreenAction>
                                             <Tooltip
                                                 title={isExpPanelExpanded ? 'Collapse' : 'Expand'}
@@ -841,22 +885,6 @@ function RunViewContent({
                                                 </ExpandingActionButton>
                                             </Tooltip>
                                         </LargeScreenAction>
-                                        <Tooltip title="Close" placement="bottom">
-                                            <ExpandingActionButton
-                                                aria-label="Close experiment details"
-                                                onClick={handleClosePanel}
-                                                size="small"
-                                                variant="outlined"
-                                                data-test-id={TEST_ID_EXPERIMENT_DETAILS_CLOSE}
-                                                {...mkCloseExperimentDetailsPanelAttrs({
-                                                    runId: run.id,
-                                                })}>
-                                                <CloseIcon fontSize="small" />
-                                                <ButtonLabel className="button-label">
-                                                    Close
-                                                </ButtonLabel>
-                                            </ExpandingActionButton>
-                                        </Tooltip>
                                     </>
                                 }
                             />

--- a/ui/src/app/runs/components/RunViewPanels.tsx
+++ b/ui/src/app/runs/components/RunViewPanels.tsx
@@ -214,7 +214,9 @@ export const ExperimentPanel = styled('div')<{ $isExpanded: boolean; $isClosing?
     max-width: ${({ $isExpanded }) =>
         $isExpanded ? 'initial' : 'var(--experiment-panel-width, 500px)'};
     background-color: #163638f9;
+    border: 1px solid ${({ theme }) => theme.color['cream-20'].rgba.toString()};
     border-radius: 12px;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
     position: ${({ $isExpanded }) => ($isExpanded ? 'absolute' : 'relative')};
     overflow-y: auto;
     z-index: 2;

--- a/ui/src/app/runs/hooks/useRunSetup.ts
+++ b/ui/src/app/runs/hooks/useRunSetup.ts
@@ -2,9 +2,10 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import debounce from 'lodash.debounce';
 
 import { useViewerCredits } from '@/contexts/ViewerCreditsContext';
+import { useRuntimeConfig } from '@/contexts/RuntimeConfigContext';
 import { useViewerRuns } from '@/contexts/ViewerRunsContext';
 import { useToasts } from '@/contexts/ToastsContext';
-import { getRunsApi } from '@/api/RunsApi';
+import { getRunsApi, LocalDatasetFile, LocalDatasetInfo, ProviderInfo } from '@/api/RunsApi';
 import { getRunFromApi, getRunDetailsFromApi } from '@/types/Run';
 import { uploadToGCS as uploadFileToGCS } from '@/api/gcsUpload';
 import { PRELOADED_DATASETS } from '@/runs/utils/preloadedDatasets';
@@ -39,6 +40,13 @@ type Settings = {
     evidenceWeight: number;
     warmstartExperiments: string;
     nWarmstart: number;
+    llmProvider: 'current' | 'copilot';
+    embeddingProvider: 'current' | 'copilot';
+    model: string;
+    beliefModel: string;
+    visionModel: string;
+    embeddingModel: string;
+    embeddingDimensions: number;
 
     // Lineage (read-only, preserved across saves)
     parentRunId: string | null;
@@ -65,6 +73,7 @@ export enum UploadStatus {
 
 export interface FileUploadState {
     file: File;
+    relativePath?: string;
     description: string;
     status: UploadStatus;
     progress: number; // 0-100
@@ -78,15 +87,22 @@ export interface FileUploadState {
     abortController: AbortController | null;
 }
 
+export function getLocalFilePath(file: File): string {
+    return file.webkitRelativePath || file.name;
+}
+
 interface FieldErrors {
     name?: string;
     datasets?: string;
     datasetsDescription?: string;
     nExperiments?: string;
+    provider?: string;
+    embeddingProvider?: string;
 }
 
 export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: UseRunSetupProps) {
     const { credits } = useViewerCredits();
+    const { isLocal, isLoading: isRuntimeLoading } = useRuntimeConfig();
     const { updateViewerRun, viewerRuns } = useViewerRuns();
     const { addErrorToast } = useToasts();
     const api = getRunsApi();
@@ -94,14 +110,14 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
     const [hasAi1Permission, setHasAi1Permission] = useState(false);
     const [preloadedDescs, setPreloadedDescs] = useState<Record<string, string>>({});
     const selectedPreloadedDatasets = useMemo(() => {
-        if (!hasAi1Permission) return [];
+        if (isLocal || !hasAi1Permission) return [];
         return PRELOADED_DATASETS.filter((d) => selectedIds.has(d.id)).map((d) => ({
             ...d,
             description: preloadedDescs[d.id] ?? d.description,
         }));
-    }, [selectedIds, preloadedDescs, hasAi1Permission]);
+    }, [selectedIds, preloadedDescs, hasAi1Permission, isLocal]);
 
-    const creditsAvailable = credits?.available ?? 0;
+    const experimentLimit = isLocal ? 500 : credits?.available ?? 0;
 
     // Get max file size from the run
     const maxFileSize = viewerRuns?.[runid]?.maxFileSize || null;
@@ -121,9 +137,46 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
         evidenceWeight: 2,
         warmstartExperiments: '',
         nWarmstart: 0,
+        llmProvider: 'copilot',
+        embeddingProvider: 'copilot',
+        model: 'claude-sonnet-4.6',
+        beliefModel: 'claude-sonnet-4.6',
+        visionModel: 'claude-sonnet-4.6',
+        embeddingModel: 'text-embedding-3-small',
+        embeddingDimensions: 1536,
         parentRunId: null,
         parentRunName: null,
     });
+    const [providers, setProviders] = useState<ProviderInfo[]>([]);
+    const [localDatasets, setLocalDatasets] = useState<LocalDatasetInfo[]>([]);
+    const [localCatalogPath, setLocalCatalogPath] = useState('');
+    const [selectedLocalDataset, setSelectedLocalDataset] = useState('');
+    const [localFolderPath, setLocalFolderPath] = useState('');
+    const [activeLocalDataset, setActiveLocalDataset] = useState('');
+    const [isSelectingLocalDataset, setIsSelectingLocalDataset] = useState(false);
+    const [localDatasetError, setLocalDatasetError] = useState<string | null>(null);
+
+    useEffect(() => {
+        api.getProviders()
+            .then(({ data }) => setProviders(data.providers))
+            .catch((error) => {
+                console.error('Failed to load providers:', error);
+                setProviders([]);
+            });
+    }, [api]);
+
+    useEffect(() => {
+        if (!isLocal) return;
+        api.listLocalDatasets()
+            .then(({ data }) => {
+                setLocalDatasets(data.datasets);
+                setLocalCatalogPath(data.catalog_path);
+            })
+            .catch((error) => {
+                console.error('Failed to load local datasets:', error);
+                setLocalDatasetError('Could not read the local dataset folder.');
+            });
+    }, [api, isLocal]);
 
     // Field validation errors
     const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
@@ -146,7 +199,7 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
             try {
                 // No userid needed - API will use authenticated user
                 const { data } = await api.getRun({ runId: runid });
-                setHasAi1Permission(data.can_view_datasets ?? false);
+                setHasAi1Permission(!isLocal && (data.can_view_datasets ?? false));
                 const run = getRunFromApi(data);
                 const { metadata } = run;
 
@@ -165,6 +218,37 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
                         warmstartExperiments:
                             metadata.warmstartExperiments ?? prev.warmstartExperiments,
                         nWarmstart: metadata.nWarmstart ?? prev.nWarmstart,
+                        llmProvider: isLocal ? 'copilot' : metadata.llmProvider ?? prev.llmProvider,
+                        embeddingProvider: isLocal
+                            ? 'copilot'
+                            : metadata.embeddingProvider ?? prev.embeddingProvider,
+                        model: isLocal
+                            ? !metadata.model ||
+                              metadata.llmProvider === 'current' ||
+                              metadata.model === 'claude-haiku-4.5'
+                                ? 'claude-sonnet-4.6'
+                                : metadata.model
+                            : metadata.model ?? prev.model,
+                        beliefModel: isLocal
+                            ? !metadata.beliefModel ||
+                              metadata.llmProvider === 'current' ||
+                              metadata.beliefModel === 'claude-haiku-4.5'
+                                ? 'claude-sonnet-4.6'
+                                : metadata.beliefModel
+                            : metadata.beliefModel ?? prev.beliefModel,
+                        visionModel: isLocal
+                            ? !metadata.visionModel ||
+                              metadata.llmProvider === 'current' ||
+                              metadata.visionModel === 'claude-haiku-4.5'
+                                ? 'claude-sonnet-4.6'
+                                : metadata.visionModel
+                            : metadata.visionModel ?? prev.visionModel,
+                        embeddingModel: isLocal
+                            ? 'text-embedding-3-small'
+                            : metadata.embeddingModel ?? prev.embeddingModel,
+                        embeddingDimensions: isLocal
+                            ? 1536
+                            : metadata.embeddingDimensions ?? prev.embeddingDimensions,
                         parentRunId: metadata.parentRunId ?? null,
                         parentRunName: metadata.parentRunName ?? null,
                     }));
@@ -178,12 +262,13 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
 
                             // Create placeholder File object from filename
                             // The actual file content is already in GCS, so we just need the metadata
-                            const placeholderFile = new File([], dataset.name, {
+                            const placeholderFile = new File([], dataset.name.split('/').pop()!, {
                                 type: contentType,
                             });
 
                             return {
                                 file: placeholderFile,
+                                relativePath: dataset.name,
                                 description: dataset.description || '',
                                 status: UploadStatus.COMPLETED,
                                 progress: 100,
@@ -199,6 +284,9 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
                         });
 
                         setFileUploads(uploadStates);
+                        if (isLocal) {
+                            setActiveLocalDataset(metadata.datasets[0].name.split('/')[0]);
+                        }
                     }
                 }
             } catch (err) {
@@ -252,7 +340,7 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
     useEffect(() => {
         fileUploads.forEach((upload, index) => {
             // Create unique key for this upload
-            const uploadKey = `${upload.file.name}-${upload.file.size}-${index}`;
+            const uploadKey = `${getLocalFilePath(upload.file)}-${upload.file.size}-${index}`;
 
             if (
                 upload.status === UploadStatus.PENDING &&
@@ -279,7 +367,9 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
         const uploads = fileUploadsRef.current
             .filter((upload) => upload.status === UploadStatus.COMPLETED)
             .map((upload) => ({
-                name: upload.file.name,
+                name: isLocal
+                    ? upload.relativePath || getLocalFilePath(upload.file)
+                    : upload.file.name,
                 description: upload.description || '',
                 content_type: upload.file.type || 'application/octet-stream',
                 file_size_bytes: upload.totalBytes || upload.file.size,
@@ -313,6 +403,14 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
 
             const datasets = getCombinedDatasets();
             const currentSettings = settingsRef.current;
+            const modelPricing = Object.fromEntries(
+                (
+                    providers.find((provider) => provider.id === currentSettings.llmProvider)
+                        ?.models || []
+                )
+                    .filter((model) => model.pricing)
+                    .map((model) => [model.id, model.pricing!])
+            );
             const metadata = {
                 // Descriptive metadata
                 name: currentSettings.name.trim(),
@@ -328,6 +426,14 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
                 evidence_weight: currentSettings.evidenceWeight,
                 warmstart_experiments: currentSettings.warmstartExperiments,
                 n_warmstart: currentSettings.nWarmstart,
+                llm_provider: currentSettings.llmProvider,
+                embedding_provider: currentSettings.embeddingProvider,
+                model: currentSettings.model,
+                belief_model: currentSettings.beliefModel,
+                vision_model: currentSettings.visionModel,
+                embedding_model: currentSettings.embeddingModel,
+                embedding_dimensions: currentSettings.embeddingDimensions,
+                model_pricing: modelPricing,
                 // Lineage
                 lineage: {
                     parent_run_id: currentSettings.parentRunId ?? null,
@@ -358,7 +464,7 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
                 setIsSaving(false);
             }, remainingTime);
         }
-    }, [api, runid]);
+    }, [api, runid, isLocal, providers]);
 
     const uploadToGCS = async (
         index: number,
@@ -424,6 +530,20 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
                     error: null,
                 });
 
+                const { data: runtimeConfig } = await api.getRuntimeConfig();
+                if (runtimeConfig.upload_transport === 'api') {
+                    const { data } = await api.uploadDataset(runid, file, getLocalFilePath(file));
+                    updateUploadState(index, {
+                        status: UploadStatus.COMPLETED,
+                        progress: 100,
+                        uploadedBytes: file.size,
+                        secondsRemaining: 0,
+                        gcsPath: data.path,
+                    });
+                    setTimeout(() => saveDatasetMetadata(), 100);
+                    return;
+                }
+
                 // Request presigned URL from backend
                 const { data } = await api.generateUploadUrl({
                     runid,
@@ -448,7 +568,7 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
                 });
             }
         },
-        [fileUploads, runid]
+        [api, fileUploads, runid, saveDatasetMetadata]
     );
 
     const handleFileSelect = (files: File[]) => {
@@ -479,6 +599,87 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
             return rest;
         });
         setFormError(null);
+    };
+
+    const applyImportedDataset = async (files: LocalDatasetFile[], label: string) => {
+        const importedUploads: FileUploadState[] = files.map((dataset) => ({
+            file: new File([], dataset.name.split('/').pop()!, {
+                type: dataset.content_type,
+            }),
+            relativePath: dataset.name,
+            description: '',
+            status: UploadStatus.COMPLETED,
+            progress: 100,
+            uploadedBytes: dataset.file_size_bytes,
+            totalBytes: dataset.file_size_bytes,
+            secondsRemaining: 0,
+            uploadStartTime: null,
+            uploadUrl: null,
+            gcsPath: `data/${dataset.name}`,
+            error: null,
+            abortController: null,
+        }));
+        fileUploadsRef.current = importedUploads;
+        setFileUploads(importedUploads);
+        setActiveLocalDataset(label);
+        setFieldErrors((previous) => {
+            const { datasets, ...rest } = previous;
+            return rest;
+        });
+        await saveDatasetMetadata();
+    };
+
+    const importLocalDataset = async (datasetName: string) => {
+        if (!datasetName) return;
+        setSelectedLocalDataset(datasetName);
+        setIsSelectingLocalDataset(true);
+        setLocalDatasetError(null);
+        try {
+            const { data } = await api.importLocalDataset(runid, {
+                dataset_name: datasetName,
+            });
+            await applyImportedDataset(data.files, datasetName);
+        } catch (error) {
+            setLocalDatasetError(
+                error instanceof Error ? error.message : 'Dataset selection failed.'
+            );
+        } finally {
+            setIsSelectingLocalDataset(false);
+        }
+    };
+
+    const browseLocalDatasetFolder = async () => {
+        setLocalDatasetError(null);
+        try {
+            const { data } = await api.browseLocalDatasetFolder();
+            if (data.path) {
+                setLocalFolderPath(data.path);
+                await importLocalFolderPath(data.path);
+            }
+        } catch (error) {
+            setLocalDatasetError(
+                error instanceof Error ? error.message : 'Folder selection failed.'
+            );
+        }
+    };
+
+    const importLocalFolderPath = async (folderPath = localFolderPath) => {
+        if (!folderPath.trim()) return;
+        setIsSelectingLocalDataset(true);
+        setLocalDatasetError(null);
+        try {
+            const { data } = await api.importLocalDataset(runid, {
+                source_path: folderPath.trim(),
+            });
+            const label = folderPath.trim().replace(/\/$/, '').split('/').pop() || 'Dataset';
+            await applyImportedDataset(data.files, label);
+        } catch (error) {
+            setLocalDatasetError(
+                error instanceof Error ? error.message : 'Dataset selection failed.'
+            );
+        } finally {
+            setIsSelectingLocalDataset(false);
+        }
     };
 
     const handleFileDescriptionChange = (index: number, description: string) => {
@@ -544,6 +745,14 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
             // Use refs to get latest state
             const currentSettings = settingsRef.current;
             const datasets = getCombinedDatasets();
+            const modelPricing = Object.fromEntries(
+                (
+                    providers.find((provider) => provider.id === currentSettings.llmProvider)
+                        ?.models || []
+                )
+                    .filter((model) => model.pricing)
+                    .map((model) => [model.id, model.pricing!])
+            );
 
             const metadata = {
                 // Descriptive metadata
@@ -560,6 +769,14 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
                 evidence_weight: currentSettings.evidenceWeight,
                 warmstart_experiments: currentSettings.warmstartExperiments,
                 n_warmstart: currentSettings.nWarmstart,
+                llm_provider: currentSettings.llmProvider,
+                embedding_provider: currentSettings.embeddingProvider,
+                model: currentSettings.model,
+                belief_model: currentSettings.beliefModel,
+                vision_model: currentSettings.visionModel,
+                embedding_model: currentSettings.embeddingModel,
+                embedding_dimensions: currentSettings.embeddingDimensions,
+                model_pricing: modelPricing,
                 // Lineage
                 lineage: {
                     parent_run_id: currentSettings.parentRunId ?? null,
@@ -581,7 +798,7 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
                 setIsSaving(false);
             }, remainingTime);
         }
-    }, [api, runid]);
+    }, [api, runid, providers]);
 
     // Create debounced versions of save functions
     const debouncedSaveMetadata = useMemo(
@@ -617,10 +834,10 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
 
         const num = parseInt(value, 10);
 
-        if (isNaN(num) || num < 1 || num > creditsAvailable) {
+        if (isNaN(num) || num < 1 || num > experimentLimit) {
             setFieldErrors((prev) => ({
                 ...prev,
-                nExperiments: `Must be between 1 and ${creditsAvailable}`,
+                nExperiments: `Must be between 1 and ${experimentLimit}`,
             }));
         } else {
             updateSettings('nExperiments', num);
@@ -653,9 +870,22 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
         if (
             !settings.nExperiments ||
             settings.nExperiments < 1 ||
-            settings.nExperiments > creditsAvailable
+            settings.nExperiments > experimentLimit
         ) {
-            errors.nExperiments = `Must be between 1 and ${creditsAvailable}`;
+            errors.nExperiments = `Must be between 1 and ${experimentLimit}`;
+        }
+
+        const selectedProvider = providers.find((provider) => provider.id === settings.llmProvider);
+        if (!selectedProvider || selectedProvider.status !== 'ready') {
+            errors.provider =
+                selectedProvider?.remediation || 'Select an available model provider.';
+        }
+        const selectedEmbeddingProvider = providers.find(
+            (provider) => provider.id === settings.embeddingProvider
+        );
+        if (!selectedEmbeddingProvider?.embedding_ready) {
+            errors.embeddingProvider =
+                selectedEmbeddingProvider?.remediation || 'Select an available embedding provider.';
         }
 
         // Check the object keys directly
@@ -744,7 +974,9 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
 
     return {
         // Computed values
-        creditsAvailable,
+        creditsAvailable: experimentLimit,
+        isLocal,
+        providers,
 
         // Dataset upload state
         fileUploads,
@@ -759,7 +991,7 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
         formError,
 
         // Loading state
-        isLoading,
+        isLoading: isLoading || isRuntimeLoading,
 
         // Saving state
         isSaving,
@@ -785,5 +1017,17 @@ export function useRunSetup({ runid, onSubmitSuccess, debounceSaveMs = 3000 }: U
         selectedDatasetIds: selectedIds,
         togglePreloadedDataset,
         updatePreloadedDescription,
+        localDatasets,
+        localCatalogPath,
+        selectedLocalDataset,
+        setSelectedLocalDataset,
+        localFolderPath,
+        setLocalFolderPath,
+        activeLocalDataset,
+        isSelectingLocalDataset,
+        localDatasetError,
+        importLocalDataset,
+        browseLocalDatasetFolder,
+        importLocalFolderPath,
     };
 }

--- a/ui/src/app/runs/layout.tsx
+++ b/ui/src/app/runs/layout.tsx
@@ -22,7 +22,8 @@ export default function RunsLayout({ children }: { children: React.ReactNode }) 
     const { isAuthenticated } = useAuth0();
 
     // Extract runId from pathname if we're on a run detail page
-    const runIdMatch = pathname.match(/^\/runs\/([^/]+)/);
+    const isSettings = pathname === '/runs/settings';
+    const runIdMatch = isSettings ? null : pathname.match(/^\/runs\/([^/]+)/);
     const selectedRunId = runIdMatch ? runIdMatch[1] : null;
 
     const handleSelectRun = (runid: string) => {
@@ -148,6 +149,11 @@ const MainContent = styled('div')`
 
 const Logo = styled('a')`
     padding: ${({ theme }) => theme.spacing(2)};
+
+    html.autodiscovery-desktop & {
+        padding-top: ${({ theme }) => theme.spacing(6)};
+        -webkit-app-region: no-drag;
+    }
 
     svg {
         width: 100%;

--- a/ui/src/app/runs/page.tsx
+++ b/ui/src/app/runs/page.tsx
@@ -4,6 +4,7 @@ import { Box, CircularProgress, styled, Typography } from '@mui/material';
 import Image from 'next/image';
 
 import { useAuth0 } from '@/contexts/Auth0Context';
+import { useRuntimeConfig } from '@/contexts/RuntimeConfigContext';
 import { TEST_ID_AI2_LOGO_LINK, TEST_ID_ASTA_LABS_LOGO_LINK } from '@/testIds';
 import { IntroBox } from '@/runs/components/IntroBox';
 import { ExamplesRunsBox } from '@/runs/components/ExamplesRunsBox';
@@ -16,6 +17,8 @@ import { AstaAdBanner } from '@/components/AstaAdBanner';
  */
 export default function RunsPage() {
     const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0();
+    const { config } = useRuntimeConfig();
+    const hostedFeatures = config?.hosted_features === true;
 
     if (isLoading) {
         return (
@@ -69,14 +72,16 @@ export default function RunsPage() {
                             experiment.
                         </Attribution>
                     </Section>
-                    <Section>
-                        <ExamplesRunsBox />
-                    </Section>
+                    {hostedFeatures && (
+                        <Section>
+                            <ExamplesRunsBox />
+                        </Section>
+                    )}
                     <FooterWrapper>
                         <ToS />
                     </FooterWrapper>
                 </LoggedOutLayout>
-                <AstaAdBanner isFullWidth />
+                {hostedFeatures && <AstaAdBanner isFullWidth />}
             </>
         );
     }
@@ -89,10 +94,12 @@ export default function RunsPage() {
             <Section>
                 <ViewerRunsBox />
             </Section>
-            <Section>
-                <ExamplesRunsBox />
-            </Section>
-            <AstaAdBanner />
+            {hostedFeatures && (
+                <Section>
+                    <ExamplesRunsBox />
+                </Section>
+            )}
+            {hostedFeatures && <AstaAdBanner />}
         </Layout>
     );
 }

--- a/ui/src/app/runs/settings/page.tsx
+++ b/ui/src/app/runs/settings/page.tsx
@@ -1,0 +1,717 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+    Alert,
+    Box,
+    Button,
+    CircularProgress,
+    FormHelperText,
+    FormLabel,
+    Stack,
+    TextField,
+    Typography,
+    styled,
+} from '@mui/material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import LoginOutlinedIcon from '@mui/icons-material/LoginOutlined';
+import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined';
+import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
+import LinkOffOutlinedIcon from '@mui/icons-material/LinkOffOutlined';
+
+import {
+    CopilotLoginStatus,
+    getRunsApi,
+    ProviderConfigurationResponseBody,
+    ProviderInfo,
+} from '@/api/RunsApi';
+import { MenuLinks } from '@/components/MenuLinks';
+import { useRuntimeConfig } from '@/contexts/RuntimeConfigContext';
+
+export default function SettingsPage() {
+    const api = getRunsApi();
+    const { isLocal, isLoading: isRuntimeLoading } = useRuntimeConfig();
+    const [providers, setProviders] = useState<ProviderInfo[]>([]);
+    const [isSigningIn, setIsSigningIn] = useState(false);
+    const [copilotLogin, setCopilotLogin] = useState<CopilotLoginStatus | null>(null);
+    const [copiedCode, setCopiedCode] = useState(false);
+    const [isDisconnecting, setIsDisconnecting] = useState(false);
+    const [configuration, setConfiguration] = useState<
+        ProviderConfigurationResponseBody['providers'] | null
+    >(null);
+    const [editingProvider, setEditingProvider] = useState<'openai' | 'vertex' | null>(null);
+    const [openaiKey, setOpenaiKey] = useState('');
+    const [vertexToken, setVertexToken] = useState('');
+    const [vertexProject, setVertexProject] = useState('');
+    const [vertexLocation, setVertexLocation] = useState('global');
+    const [isSavingProvider, setIsSavingProvider] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const loadProviders = useCallback(async () => {
+        setError(null);
+        try {
+            const { data: providerData } = await api.getProviders();
+            setProviders(providerData.providers);
+        } catch (requestError) {
+            setError(
+                requestError instanceof Error
+                    ? requestError.message
+                    : 'Could not check AI providers.'
+            );
+        }
+    }, [api]);
+
+    useEffect(() => {
+        const loadInitialSettings = async () => {
+            try {
+                const { data } = await api.getProviderConfiguration();
+                setConfiguration(data.providers);
+                setVertexProject(data.providers.vertex.project_id || '');
+                setVertexLocation(data.providers.vertex.location || 'global');
+            } catch (requestError) {
+                setError(
+                    requestError instanceof Error
+                        ? requestError.message
+                        : 'Could not load provider configuration.'
+                );
+            }
+            loadProviders();
+        };
+        loadInitialSettings();
+    }, [api, loadProviders]);
+
+    const startCopilotLogin = async () => {
+        setIsSigningIn(true);
+        setCopilotLogin(null);
+        setCopiedCode(false);
+        setError(null);
+        try {
+            const { data } = await api.startCopilotLogin();
+            setCopilotLogin(data);
+        } catch (requestError) {
+            setError(
+                requestError instanceof Error
+                    ? requestError.message
+                    : 'Could not open Copilot sign-in.'
+            );
+            setIsSigningIn(false);
+            return;
+        }
+
+        const deadline = Date.now() + 2 * 60 * 1000;
+        const finishLogin = () => {
+            window.clearInterval(statusPoll);
+            setIsSigningIn(false);
+        };
+        const statusPoll = window.setInterval(async () => {
+            try {
+                const { data: loginData } = await api.getCopilotLoginStatus();
+                setCopilotLogin(loginData);
+                if (loginData.phase === 'completed') {
+                    const [{ data: configurationData }, { data: providerData }] = await Promise.all(
+                        [api.getProviderConfiguration(), api.getProviders()]
+                    );
+                    setConfiguration(configurationData.providers);
+                    setProviders(providerData.providers);
+                    setCopilotLogin(null);
+                    finishLogin();
+                } else if (loginData.phase === 'failed' || Date.now() >= deadline) {
+                    finishLogin();
+                }
+            } catch {
+                if (Date.now() >= deadline) finishLogin();
+            }
+        }, 500);
+    };
+
+    const copyCopilotCode = async () => {
+        if (!copilotLogin?.device_code) return;
+        await navigator.clipboard.writeText(copilotLogin.device_code);
+        setCopiedCode(true);
+    };
+
+    const openCopilotVerification = () => {
+        window.open(
+            copilotLogin?.verification_url || 'https://github.com/login/device',
+            '_blank',
+            'noopener,noreferrer'
+        );
+    };
+
+    const disconnectCopilot = async () => {
+        setIsDisconnecting(true);
+        setError(null);
+        try {
+            await api.disconnectCopilot();
+            setConfiguration((previous) =>
+                previous ? { ...previous, copilot: { configured: false } } : previous
+            );
+            setProviders((previous) =>
+                previous.map((provider) =>
+                    provider.id === 'copilot'
+                        ? {
+                              ...provider,
+                              status: 'error',
+                              code: 'AUTH_REQUIRED',
+                              message: 'Copilot is not connected.',
+                              embedding_ready: false,
+                              models: [],
+                          }
+                        : provider
+                )
+            );
+        } catch (requestError) {
+            setError(
+                requestError instanceof Error
+                    ? requestError.message
+                    : 'Could not disconnect Copilot.'
+            );
+        } finally {
+            setIsDisconnecting(false);
+        }
+    };
+
+    const saveExternalProvider = async (provider: 'openai' | 'vertex') => {
+        setIsSavingProvider(true);
+        setError(null);
+        try {
+            const response =
+                provider === 'openai'
+                    ? await api.saveProviderConfiguration('openai', { api_key: openaiKey })
+                    : await api.saveProviderConfiguration('vertex', {
+                          access_token: vertexToken,
+                          project_id: vertexProject,
+                          location: vertexLocation,
+                      });
+            const { data } = response;
+            setConfiguration(data.providers);
+            setOpenaiKey('');
+            setVertexToken('');
+            setEditingProvider(null);
+        } catch (requestError) {
+            setError(
+                requestError instanceof Error
+                    ? requestError.message
+                    : 'Could not save provider configuration.'
+            );
+        } finally {
+            setIsSavingProvider(false);
+        }
+    };
+
+    const removeExternalProvider = async (provider: 'openai' | 'vertex') => {
+        setIsSavingProvider(true);
+        setError(null);
+        try {
+            const { data } = await api.deleteProviderConfiguration(provider);
+            setConfiguration(data.providers);
+            setEditingProvider(null);
+        } catch (requestError) {
+            setError(
+                requestError instanceof Error
+                    ? requestError.message
+                    : 'Could not remove provider configuration.'
+            );
+        } finally {
+            setIsSavingProvider(false);
+        }
+    };
+
+    if (isRuntimeLoading) {
+        return <CenteredProgress />;
+    }
+
+    if (!isLocal) {
+        return <Alert severity="info">Provider settings are available in the local app.</Alert>;
+    }
+
+    const copilot = providers.find((provider) => provider.id === 'copilot');
+    const copilotConfigured = configuration?.copilot.configured === true;
+    const copilotConnected = copilotConfigured && copilot?.status === 'ready' && !isSigningIn;
+
+    return (
+        <Page>
+            <Header>
+                <Typography component="h1">Settings</Typography>
+                <Typography>
+                    Connect and check the AI providers available to AutoDiscovery.
+                </Typography>
+            </Header>
+
+            {error && <Alert severity="error">{error}</Alert>}
+
+            <Section>
+                <SectionHeading>AI providers</SectionHeading>
+                {!configuration ? (
+                    <CenteredProgress />
+                ) : (
+                    <ProviderList>
+                        <ProviderRow>
+                            <ProviderSummary>
+                                <ProviderName>GitHub Copilot</ProviderName>
+                                <ProviderStatus $ready={copilotConnected}>
+                                    {copilotConnected ? (
+                                        <CheckCircleOutlineIcon fontSize="small" />
+                                    ) : (
+                                        <ErrorOutlineIcon fontSize="small" />
+                                    )}
+                                    {copilotConnected
+                                        ? 'Connected'
+                                        : copilotConfigured
+                                          ? 'Signed in · checking connection'
+                                          : 'Not connected'}
+                                </ProviderStatus>
+                                <ProviderMessage>
+                                    {copilot?.message || 'Checking Copilot availability…'}
+                                </ProviderMessage>
+                                {copilotConnected && copilot && (
+                                    <ProviderMeta>
+                                        {copilot.models.length} models · Embeddings{' '}
+                                        {copilot.embedding_ready ? 'available' : 'unavailable'}
+                                    </ProviderMeta>
+                                )}
+                            </ProviderSummary>
+                            <ProviderActions>
+                                {copilotConfigured ? (
+                                    <ActionButton
+                                        variant="outlined"
+                                        startIcon={<LinkOffOutlinedIcon />}
+                                        onClick={disconnectCopilot}
+                                        disabled={isSigningIn || isDisconnecting}>
+                                        Disconnect
+                                    </ActionButton>
+                                ) : (
+                                    <PrimaryAction
+                                        variant="outlined"
+                                        startIcon={
+                                            isSigningIn ? (
+                                                <CircularProgress size={16} />
+                                            ) : (
+                                                <LoginOutlinedIcon />
+                                            )
+                                        }
+                                        onClick={startCopilotLogin}
+                                        disabled={isSigningIn || isDisconnecting}>
+                                        Sign in
+                                    </PrimaryAction>
+                                )}
+                            </ProviderActions>
+                        </ProviderRow>
+                        {isSigningIn && (
+                            <LoginPanel>
+                                <ProviderName>Connect GitHub Copilot</ProviderName>
+                                <ProviderMessage>
+                                    Sign into GitHub in the browser, then enter this code when
+                                    asked.
+                                </ProviderMessage>
+                                {copilotLogin?.device_code ? (
+                                    <DeviceCode>{copilotLogin.device_code}</DeviceCode>
+                                ) : (
+                                    <DeviceCodeLoading>
+                                        <CircularProgress size={18} /> Preparing code…
+                                    </DeviceCodeLoading>
+                                )}
+                                <LoginActions>
+                                    <ActionButton
+                                        variant="outlined"
+                                        startIcon={<ContentCopyOutlinedIcon />}
+                                        onClick={copyCopilotCode}
+                                        disabled={!copilotLogin?.device_code}>
+                                        {copiedCode ? 'Copied' : 'Copy code'}
+                                    </ActionButton>
+                                    <PrimaryAction
+                                        variant="outlined"
+                                        onClick={openCopilotVerification}
+                                        startIcon={<OpenInNewOutlinedIcon />}>
+                                        Open GitHub
+                                    </PrimaryAction>
+                                </LoginActions>
+                            </LoginPanel>
+                        )}
+
+                        {configuration && (
+                            <ProviderRow>
+                                <ProviderSummary>
+                                    <ProviderName>OpenAI</ProviderName>
+                                    <ProviderStatus $ready={configuration.openai.configured}>
+                                        {configuration.openai.configured ? (
+                                            <CheckCircleOutlineIcon fontSize="small" />
+                                        ) : (
+                                            <ErrorOutlineIcon fontSize="small" />
+                                        )}
+                                        {configuration.openai.configured
+                                            ? 'Configured'
+                                            : 'Not configured'}
+                                    </ProviderStatus>
+                                    <ProviderMessage>
+                                        Use an OpenAI API key for GPT models and OpenAI embeddings.
+                                    </ProviderMessage>
+                                </ProviderSummary>
+                                <ProviderActions>
+                                    <ActionButton
+                                        variant="outlined"
+                                        onClick={() => setEditingProvider('openai')}>
+                                        {configuration.openai.configured ? 'Update' : 'Configure'}
+                                    </ActionButton>
+                                    {configuration.openai.configured && (
+                                        <RemoveButton
+                                            variant="text"
+                                            onClick={() => removeExternalProvider('openai')}
+                                            disabled={isSavingProvider}>
+                                            Remove
+                                        </RemoveButton>
+                                    )}
+                                </ProviderActions>
+                            </ProviderRow>
+                        )}
+                        {editingProvider === 'openai' && (
+                            <CredentialForm>
+                                <CredentialLabel htmlFor="openai-api-key">
+                                    OpenAI API key
+                                </CredentialLabel>
+                                <CredentialField
+                                    id="openai-api-key"
+                                    type="password"
+                                    value={openaiKey}
+                                    onChange={(event) => setOpenaiKey(event.target.value)}
+                                    autoComplete="off"
+                                    placeholder="sk-…"
+                                />
+                                <CredentialHelp>
+                                    Stored in macOS Keychain. The key is never returned to the UI.
+                                </CredentialHelp>
+                                <FormActions>
+                                    <ActionButton onClick={() => setEditingProvider(null)}>
+                                        Cancel
+                                    </ActionButton>
+                                    <PrimaryAction
+                                        variant="outlined"
+                                        onClick={() => saveExternalProvider('openai')}
+                                        disabled={!openaiKey.trim() || isSavingProvider}>
+                                        Save OpenAI
+                                    </PrimaryAction>
+                                </FormActions>
+                            </CredentialForm>
+                        )}
+
+                        {configuration && (
+                            <ProviderRow>
+                                <ProviderSummary>
+                                    <ProviderName>Google Vertex AI</ProviderName>
+                                    <ProviderStatus $ready={configuration.vertex.configured}>
+                                        {configuration.vertex.configured ? (
+                                            <CheckCircleOutlineIcon fontSize="small" />
+                                        ) : (
+                                            <ErrorOutlineIcon fontSize="small" />
+                                        )}
+                                        {configuration.vertex.configured
+                                            ? 'Configured'
+                                            : 'Not configured'}
+                                    </ProviderStatus>
+                                    <ProviderMessage>
+                                        Use a Vertex access token, project, and location for Gemini.
+                                    </ProviderMessage>
+                                </ProviderSummary>
+                                <ProviderActions>
+                                    <ActionButton
+                                        variant="outlined"
+                                        onClick={() => setEditingProvider('vertex')}>
+                                        {configuration.vertex.configured ? 'Update' : 'Configure'}
+                                    </ActionButton>
+                                    {configuration.vertex.configured && (
+                                        <RemoveButton
+                                            variant="text"
+                                            onClick={() => removeExternalProvider('vertex')}
+                                            disabled={isSavingProvider}>
+                                            Remove
+                                        </RemoveButton>
+                                    )}
+                                </ProviderActions>
+                            </ProviderRow>
+                        )}
+                        {editingProvider === 'vertex' && (
+                            <CredentialForm>
+                                <CredentialLabel htmlFor="vertex-access-token">
+                                    Vertex access token
+                                </CredentialLabel>
+                                <CredentialField
+                                    id="vertex-access-token"
+                                    type="password"
+                                    value={vertexToken}
+                                    onChange={(event) => setVertexToken(event.target.value)}
+                                    autoComplete="off"
+                                />
+                                <CredentialLabel htmlFor="vertex-project-id">
+                                    Project ID
+                                </CredentialLabel>
+                                <CredentialField
+                                    id="vertex-project-id"
+                                    value={vertexProject}
+                                    onChange={(event) => setVertexProject(event.target.value)}
+                                />
+                                <CredentialLabel htmlFor="vertex-location">
+                                    Location
+                                </CredentialLabel>
+                                <CredentialField
+                                    id="vertex-location"
+                                    value={vertexLocation}
+                                    onChange={(event) => setVertexLocation(event.target.value)}
+                                    placeholder="global"
+                                />
+                                <CredentialHelp>
+                                    Stored in macOS Keychain. Access tokens expire and may need to
+                                    be updated.
+                                </CredentialHelp>
+                                <FormActions>
+                                    <ActionButton onClick={() => setEditingProvider(null)}>
+                                        Cancel
+                                    </ActionButton>
+                                    <PrimaryAction
+                                        variant="outlined"
+                                        onClick={() => saveExternalProvider('vertex')}
+                                        disabled={
+                                            !vertexToken.trim() ||
+                                            !vertexProject.trim() ||
+                                            isSavingProvider
+                                        }>
+                                        Save Vertex AI
+                                    </PrimaryAction>
+                                </FormActions>
+                            </CredentialForm>
+                        )}
+                    </ProviderList>
+                )}
+            </Section>
+
+            <Section>
+                <SectionHeading>Resources & policies</SectionHeading>
+                <PolicyLinks>
+                    <MenuLinks layout="settings" />
+                </PolicyLinks>
+            </Section>
+        </Page>
+    );
+}
+
+const Page = styled(Stack)(({ theme }) => ({
+    gap: theme.spacing(3),
+    margin: '0 auto',
+    maxWidth: 900,
+    padding: theme.spacing(3),
+}));
+
+const Header = styled(Box)(({ theme }) => ({
+    color: theme.color['cream-80'].rgba.toString(),
+    '& h1': {
+        color: theme.color['green-100'].hex,
+        fontSize: '1.5rem',
+        fontWeight: 700,
+        marginBottom: theme.spacing(0.5),
+    },
+}));
+
+const Section = styled(Box)(({ theme }) => ({
+    backgroundColor: theme.color['cream-4'].rgba.toString(),
+    borderRadius: 8,
+    padding: theme.spacing(3),
+}));
+
+const SectionHeading = styled(Typography)(({ theme }) => ({
+    color: theme.color['green-40'].hex,
+    fontSize: '1rem',
+    fontWeight: 700,
+    marginBottom: theme.spacing(2),
+}));
+
+const ProviderList = styled(Stack)(({ theme }) => ({
+    gap: theme.spacing(0),
+}));
+
+const CredentialForm = styled(Stack)(({ theme }) => ({
+    borderTop: `1px solid ${theme.color['cream-10'].rgba.toString()}`,
+    gap: theme.spacing(1),
+    padding: theme.spacing(2, 0, 3),
+}));
+
+const LoginPanel = styled(Stack)(({ theme }) => ({
+    backgroundColor: theme.color['cream-4'].rgba.toString(),
+    border: `1px solid ${theme.color['cream-10'].rgba.toString()}`,
+    borderRadius: 4,
+    gap: theme.spacing(1),
+    margin: theme.spacing(0, 0, 2),
+    padding: theme.spacing(2),
+}));
+
+const DeviceCode = styled(Typography)(({ theme }) => ({
+    color: theme.color['cream-100'].hex,
+    fontFamily: 'monospace',
+    fontSize: '1.5rem',
+    fontWeight: 700,
+    letterSpacing: 0,
+    marginTop: theme.spacing(1),
+}));
+
+const DeviceCodeLoading = styled(Box)(({ theme }) => ({
+    alignItems: 'center',
+    color: theme.color['cream-60'].rgba.toString(),
+    display: 'flex',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1),
+}));
+
+const LoginActions = styled(Stack)(({ theme }) => ({
+    flexDirection: 'row',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1),
+}));
+
+const CredentialLabel = styled(FormLabel)(({ theme }) => ({
+    color: theme.color['green-40'].hex,
+    fontWeight: 700,
+    marginTop: theme.spacing(1),
+}));
+
+const CredentialField = styled(TextField)(({ theme }) => ({
+    '& .MuiOutlinedInput-root': {
+        color: theme.color['cream-100'].hex,
+        '& fieldset': { borderColor: theme.color['cream-20'].rgba.toString() },
+        '&:hover fieldset, &.Mui-focused fieldset': {
+            borderColor: theme.color['green-100'].hex,
+        },
+    },
+}));
+
+const CredentialHelp = styled(FormHelperText)(({ theme }) => ({
+    color: theme.color['cream-60'].rgba.toString(),
+    margin: theme.spacing(0.5, 0, 0),
+}));
+
+const FormActions = styled(Stack)(({ theme }) => ({
+    flexDirection: 'row',
+    gap: theme.spacing(1),
+    justifyContent: 'flex-end',
+    marginTop: theme.spacing(1),
+}));
+
+const ProviderRow = styled(Box)(({ theme }) => ({
+    alignItems: 'center',
+    borderTop: `1px solid ${theme.color['cream-10'].rgba.toString()}`,
+    display: 'flex',
+    gap: theme.spacing(3),
+    justifyContent: 'space-between',
+    padding: theme.spacing(2, 0),
+    '&:first-of-type': { borderTop: 0, paddingTop: 0 },
+    '@media (max-width: 700px)': { alignItems: 'stretch', flexDirection: 'column' },
+}));
+
+const ProviderSummary = styled(Box)({ minWidth: 0 });
+
+const ProviderName = styled(Typography)(({ theme }) => ({
+    color: theme.color['cream-100'].hex,
+    fontWeight: 700,
+}));
+
+const ProviderStatus = styled(Box, {
+    shouldForwardProp: (prop) => prop !== '$ready',
+})<{ $ready: boolean }>(({ theme, $ready }) => ({
+    alignItems: 'center',
+    color: $ready ? theme.color['green-100'].hex : theme.color['cream-60'].rgba.toString(),
+    display: 'flex',
+    fontSize: '0.875rem',
+    gap: theme.spacing(0.75),
+    marginTop: theme.spacing(0.75),
+}));
+
+const ProviderMessage = styled(Typography)(({ theme }) => ({
+    color: theme.color['cream-80'].rgba.toString(),
+    fontSize: '0.875rem',
+    marginTop: theme.spacing(0.75),
+}));
+
+const ProviderMeta = styled(Typography)(({ theme }) => ({
+    color: theme.color['cream-60'].rgba.toString(),
+    fontSize: '0.875rem',
+    marginTop: theme.spacing(0.5),
+}));
+
+const ProviderActions = styled(Stack)(({ theme }) => ({
+    alignItems: 'center',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    flexShrink: 0,
+    gap: theme.spacing(1),
+    justifyContent: 'flex-end',
+}));
+
+const ActionButton = styled(Button)(({ theme }) => ({
+    '&&': {
+        backgroundColor: 'transparent',
+        border: `1px solid ${theme.color['cream-20'].rgba.toString()}`,
+        borderRadius: 4,
+        color: theme.color['cream-100'].hex,
+        height: 40,
+        padding: theme.spacing(0, 2),
+        '&:hover': {
+            backgroundColor: 'transparent',
+            borderColor: theme.color['cream-40'].rgba.toString(),
+            color: theme.color['green-100'].hex,
+        },
+        '&.Mui-disabled': {
+            borderColor: theme.color['cream-10'].rgba.toString(),
+            color: theme.color['cream-40'].rgba.toString(),
+        },
+    },
+}));
+
+const PrimaryAction = styled(Button)(({ theme }) => ({
+    '&&': {
+        backgroundColor: 'transparent',
+        border: `1px solid ${theme.color['green-40'].rgba.toString()}`,
+        borderRadius: 4,
+        color: theme.color['cream-100'].hex,
+        height: 40,
+        padding: theme.spacing(0, 2),
+        '&:hover': {
+            backgroundColor: 'transparent',
+            borderColor: theme.color['green-100'].hex,
+            color: theme.color['green-100'].hex,
+        },
+        '&.Mui-disabled': {
+            borderColor: theme.color['cream-10'].rgba.toString(),
+            color: theme.color['cream-40'].rgba.toString(),
+        },
+    },
+}));
+
+const RemoveButton = styled(Button)(({ theme }) => ({
+    '&&': {
+        color: theme.color['error-red-60'].hex,
+        height: 40,
+        padding: theme.spacing(0, 1.5),
+    },
+}));
+
+const PolicyLinks = styled(Box)(({ theme }) => ({
+    '& > div': {
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+        padding: 0,
+    },
+    '& > div + div': { borderTop: 0 },
+    '& a, & button': {
+        borderBottom: `1px solid ${theme.color['cream-10'].rgba.toString()}`,
+        color: theme.color['cream-80'].rgba.toString(),
+    },
+    '@media (max-width: 700px)': {
+        '& > div': { gridTemplateColumns: '1fr' },
+    },
+}));
+
+function CenteredProgress() {
+    return (
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+            <CircularProgress />
+        </Box>
+    );
+}

--- a/ui/src/app/runs/utils/localCostEstimate.ts
+++ b/ui/src/app/runs/utils/localCostEstimate.ts
@@ -1,0 +1,83 @@
+export interface LocalCostEstimate {
+    experiments: number;
+    totalTokens: number;
+    lowUSD: number;
+    highUSD: number;
+    livePricing: boolean;
+}
+
+interface ModelPrice {
+    inputPerMillion: number;
+    outputPerMillion: number;
+}
+
+// Grounded Round 1 token volumes. Belief volume includes one prior/posterior vote pair.
+const TOKENS = {
+    reasoningInputPerExperiment: 11_866,
+    reasoningOutputPerExperiment: 1_183,
+    codingInputPerExperiment: 3_673,
+    codingOutputPerExperiment: 2_084,
+    beliefInputPerVote: 4_848,
+    beliefOutputPerVote: 320,
+    beliefVotesPerExperiment: 5,
+};
+
+const COST_BAND = { low: 0.7, high: 1.8 };
+
+const FAMILY_PRICES: Array<{ match: string; price: ModelPrice }> = [
+    { match: 'opus', price: { inputPerMillion: 5, outputPerMillion: 25 } },
+    { match: 'sonnet', price: { inputPerMillion: 3, outputPerMillion: 15 } },
+    { match: 'haiku', price: { inputPerMillion: 1, outputPerMillion: 5 } },
+    { match: 'gpt-5.4', price: { inputPerMillion: 2.5, outputPerMillion: 15 } },
+    { match: 'gpt-5', price: { inputPerMillion: 0.25, outputPerMillion: 2 } },
+    { match: 'gemini-3', price: { inputPerMillion: 0.5, outputPerMillion: 3 } },
+];
+
+function priceFor(model: string): ModelPrice {
+    const normalized = model.toLowerCase();
+    return (
+        FAMILY_PRICES.find(({ match }) => normalized.includes(match))?.price || {
+            inputPerMillion: 3,
+            outputPerMillion: 15,
+        }
+    );
+}
+
+export function estimateLocalRunCost(
+    experiments: number,
+    agentModel: string,
+    beliefModel: string,
+    agentPrice?: ModelPrice,
+    beliefPrice?: ModelPrice
+): LocalCostEstimate {
+    const safeExperiments = Math.max(0, Math.floor(experiments || 0));
+    const reasoningInput = safeExperiments * TOKENS.reasoningInputPerExperiment;
+    const reasoningOutput = safeExperiments * TOKENS.reasoningOutputPerExperiment;
+    const codingInput = safeExperiments * TOKENS.codingInputPerExperiment;
+    const codingOutput = safeExperiments * TOKENS.codingOutputPerExperiment;
+    const beliefInput =
+        safeExperiments * TOKENS.beliefVotesPerExperiment * TOKENS.beliefInputPerVote;
+    const beliefOutput =
+        safeExperiments * TOKENS.beliefVotesPerExperiment * TOKENS.beliefOutputPerVote;
+    const agentRate = agentPrice || priceFor(agentModel);
+    const beliefRate = beliefPrice || priceFor(beliefModel);
+    const priceTokens = (input: number, output: number, price: ModelPrice) =>
+        (input / 1_000_000) * price.inputPerMillion + (output / 1_000_000) * price.outputPerMillion;
+    const pointCost =
+        priceTokens(reasoningInput + codingInput, reasoningOutput + codingOutput, agentRate) +
+        priceTokens(beliefInput, beliefOutput, beliefRate);
+
+    return {
+        experiments: safeExperiments,
+        totalTokens:
+            reasoningInput +
+            reasoningOutput +
+            codingInput +
+            codingOutput +
+            beliefInput +
+            beliefOutput,
+        lowUSD: pointCost * COST_BAND.low,
+        highUSD: pointCost * COST_BAND.high,
+        livePricing: Boolean(agentPrice && beliefPrice),
+    };
+}

--- a/ui/src/app/types/Run.ts
+++ b/ui/src/app/types/Run.ts
@@ -43,6 +43,7 @@ export type Run = {
     datasetExpiresAt?: string | null;
     /** Whether the user has permission to use Asta exploration features */
     canExploreWithAsta?: boolean;
+    estimatedCostUSD?: number | null;
 };
 
 export type RunStats = {
@@ -125,6 +126,13 @@ export type Metadata = {
     evidenceWeight?: number | null;
     warmstartExperiments?: string | null;
     nWarmstart?: number | null;
+    llmProvider?: 'current' | 'copilot' | null;
+    embeddingProvider?: 'current' | 'copilot' | null;
+    model?: string | null;
+    beliefModel?: string | null;
+    visionModel?: string | null;
+    embeddingModel?: string | null;
+    embeddingDimensions?: number | null;
     // Lineage
     parentRunId?: string | null;
     parentRunName?: string | null;
@@ -146,6 +154,7 @@ export const getRunFromApi = (runFromApi: RunFromApi): Run => {
         parentRunName: runFromApi.parent_run_name ?? null,
         datasetExpiresAt: runFromApi.dataset_expires_at ?? null,
         canExploreWithAsta: runFromApi.can_explore_with_asta ?? false,
+        estimatedCostUSD: runFromApi.estimated_cost_usd ?? null,
     };
 };
 
@@ -231,6 +240,13 @@ export const getMetadataFromApi = (metadataFromApi?: MetadataFromApi): Metadata 
         evidenceWeight: metadataFromApi.evidence_weight,
         warmstartExperiments: metadataFromApi.warmstart_experiments,
         nWarmstart: metadataFromApi.n_warmstart,
+        llmProvider: metadataFromApi.llm_provider,
+        embeddingProvider: metadataFromApi.embedding_provider,
+        model: metadataFromApi.model,
+        beliefModel: metadataFromApi.belief_model,
+        visionModel: metadataFromApi.vision_model,
+        embeddingModel: metadataFromApi.embedding_model,
+        embeddingDimensions: metadataFromApi.embedding_dimensions,
         // Lineage
         parentRunId: metadataFromApi.parent_run_id ?? null,
         parentRunName: metadataFromApi.parent_run_name ?? null,


### PR DESCRIPTION
## Summary
- Adds local desktop run setup, dataset selection, runtime-aware configuration, and Copilot model defaults.
- Disables the hosted-only Explore with Asta capability in Electron/local sessions.

## Validation
- Production Next.js build completed successfully with lint and type checking.
- Local rendered run page confirmed the Explore with Asta control is absent.

## Stack
Depends on the local runtime PR below it.