### PR TITLE
Add hardened Lima code-execution backend

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,7 +113,7 @@ The AD job runs the LLM-generated experiment code through a configurable executo
 
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
-| `CODE_EXECUTION_BACKEND` | No | `process` | `process` (isolated subprocess in the job container), `local` (in-process, no isolation), or `modal` (remote sandbox). |
+| `CODE_EXECUTION_BACKEND` | No | `process` | `process` (isolated subprocess in the job container), `local` (in-process, no isolation), `modal` (remote sandbox), or `lima` (macOS VZ virtual machine). |
 
 - `process` (default) — runs code in an isolated subprocess inside the job container, in a separate
   sandbox venv; per-cell package installs are discarded, and no state carries across cells. No cloud
@@ -121,6 +121,17 @@ The AD job runs the LLM-generated experiment code through a configurable executo
 - `local` — runs code in-process with no isolation. Lowest overhead, least safe.
 - `modal` — runs code in a remote Modal sandbox that mounts **only** the per-job data prefix,
   read-only. Requires the [Modal](#modal-code-execution-sandbox-backend) variables.
+- `lima` — runs code in a Lima-managed Linux virtual machine backed by Apple
+  Virtualization.framework. Requires `AUTODISCOVERY_LIMA_PATH` to point to `limactl` and
+  `AUTODISCOVERY_LIMA_HOME` to contain a pre-provisioned instance named `ad` with Python at
+  `/opt/autodiscovery-venv/bin/python`.
+
+The Lima backend mounts only dataset parent directories read-only and the run work directory
+writable. Each cell runs as an unprivileged transient systemd service with no network, no Linux
+capabilities, a private temporary directory, a read-only system, resource limits, and an execution
+timeout. Dataset files are rebound individually as read-only paths; broad roots such as `/`,
+`/Users`, `/Volumes`, and the user's home directory are rejected. The code-execution package does
+not install Lima, create the VM, download an image, or provision guest packages.
 
 ### Choosing a safe combination
 

--- a/packages/autodiscovery/src/autodiscovery/agents.py
+++ b/packages/autodiscovery/src/autodiscovery/agents.py
@@ -382,7 +382,6 @@ from io import BytesIO
 import base64
 import json
 import os
-from openai import OpenAI
 
 VISION_MODEL = __VISION_MODEL__
 USAGE_MARKER = __USAGE_MARKER__
@@ -436,10 +435,12 @@ def _get_openai_client():
         base_url = _get_vertex_base_url()
         if not api_key or not base_url:
             return None
+        from openai import OpenAI
         return OpenAI(api_key=api_key, base_url=base_url)
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         return None
+    from openai import OpenAI
     return OpenAI(api_key=api_key)
 
 image_analyst_prompt = __IMAGE_ANALYST_PROMPT__

--- a/packages/autodiscovery/src/autodiscovery/agents.py
+++ b/packages/autodiscovery/src/autodiscovery/agents.py
@@ -923,19 +923,30 @@ def install(package):
             f"Using Modal sandbox with bucket gs://{bucket_name}/{key_prefix} mounted at {modal_mount_path}"
         )
         print(f"Working directory will be: {modal_working_dir}")
-    elif backend == "process":
+    elif backend in {"process", "lima"}:
         # Use isolated subprocess for code execution
-        from code_execution import ProcessIPythonBackend
+        if backend == "lima":
+            from code_execution import LimaIPythonBackend
 
-        process_backend = ProcessIPythonBackend(cwd=work_dir)
+            if not dataset_paths:
+                raise ValueError("dataset_paths are required when backend is 'lima'")
+            isolated_backend = LimaIPythonBackend(
+                cwd=work_dir,
+                dataset_paths=list(dataset_paths),
+            )
+        else:
+            from code_execution import ProcessIPythonBackend
+
+            isolated_backend = ProcessIPythonBackend(cwd=work_dir)
+
         executor = ModalSandboxExecutor(
-            _ProcessBackendAdapter(process_backend),
+            _ProcessBackendAdapter(isolated_backend),
             timeout=code_timeout,
             vision_model=vision_model,
             llm_provider=llm_provider,
             usage_tracker=usage_tracker,
         )
-        print(f"Using process backend with work_dir: {work_dir}")
+        print(f"Using {backend} backend with work_dir: {work_dir}")
     else:
         # Use local code executor (in-process, no isolation)
         executor = LocalCommandLineCodeExecutor(

--- a/packages/autodiscovery/src/autodiscovery/args.py
+++ b/packages/autodiscovery/src/autodiscovery/args.py
@@ -232,7 +232,7 @@ class ArgParser(argparse.ArgumentParser):
         self.add_argument(
             "--backend",
             type=str,
-            choices=["local", "process", "modal"],
+            choices=["local", "process", "modal", "lima"],
             default="process",
             help="Code execution backend: local (in-process), process (isolated subprocess, default), or modal (Modal sandbox)",
         )

--- a/packages/autodiscovery/src/autodiscovery/easy.py
+++ b/packages/autodiscovery/src/autodiscovery/easy.py
@@ -232,7 +232,7 @@ def build_parser() -> argparse.ArgumentParser:
     adv.add_argument(
         "--backend",
         type=str,
-        choices=["local", "process", "modal"],
+        choices=["local", "process", "modal", "lima"],
         default="process",
     )
     adv.add_argument("--code_timeout", type=int, default=30 * 60)

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/base.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/backends/base.py
@@ -21,7 +21,7 @@ from ..exceptions import JobBackendError
 # Code-execution backends the AD job understands (its --backend choices). "modal"
 # runs code in a remote Modal sandbox with a scoped, read-only per-job data mount;
 # "process"/"local" run it inside the job container (subprocess / in-process).
-_CODE_EXECUTION_BACKENDS = ("process", "local", "modal")
+_CODE_EXECUTION_BACKENDS = ("process", "local", "modal", "lima")
 
 
 def build_job_args(

--- a/packages/code_execution/src/code_execution/__init__.py
+++ b/packages/code_execution/src/code_execution/__init__.py
@@ -2,6 +2,7 @@
 
 from .executor import IPythonBackend, IPythonExecutor, LocalIPythonBackend
 from .ipython_session import ExecutionConfig, IPythonSession
+from .lima_backend import LimaIPythonBackend
 from .process_backend import ProcessIPythonBackend
 
 __all__ = [
@@ -10,5 +11,6 @@ __all__ = [
     "IPythonExecutor",
     "IPythonSession",
     "LocalIPythonBackend",
+    "LimaIPythonBackend",
     "ProcessIPythonBackend",
 ]

--- a/packages/code_execution/src/code_execution/lima_backend.py
+++ b/packages/code_execution/src/code_execution/lima_backend.py
@@ -1,0 +1,325 @@
+"""Virtualization.framework-backed IPython execution through Lima."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import threading
+import uuid
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from .ipython_session import ExecutionConfig
+from .process_backend import _SANDBOX_RUNNER
+
+_VM_LOCK = threading.Lock()
+_FORBIDDEN_MOUNT_ROOTS = {
+    Path("/"),
+    Path("/Users"),
+    Path("/Volumes"),
+    Path.home().resolve(),
+}
+
+
+class LimaIPythonBackend:
+    """Execute generated code in a VZ Linux VM with narrowly scoped host shares."""
+
+    def __init__(
+        self,
+        *,
+        cwd: str,
+        dataset_paths: list[str],
+        lima_path: str | None = None,
+        lima_home: str | None = None,
+        instance_name: str = "ad",
+        guest_python: str = "/opt/autodiscovery-venv/bin/python",
+    ) -> None:
+        """Configure one backend for a run work directory and approved datasets."""
+        self._cwd = Path(cwd).resolve()
+        self._dataset_paths = [Path(path).resolve() for path in dataset_paths]
+        resolved_lima_path = (
+            lima_path
+            or os.environ.get("AUTODISCOVERY_LIMA_PATH")
+            or shutil.which("limactl")
+        )
+        configured_lima_home = lima_home or os.environ.get("AUTODISCOVERY_LIMA_HOME")
+        self._lima_home = Path(configured_lima_home).expanduser() if configured_lima_home else None
+        self._instance_name = instance_name
+        self._guest_python = guest_python
+        if not resolved_lima_path or not Path(resolved_lima_path).is_file():
+            raise RuntimeError("The Lima execution backend requires AUTODISCOVERY_LIMA_PATH")
+        self._lima_path = resolved_lima_path
+        if self._lima_home is None:
+            raise RuntimeError("The Lima execution backend requires AUTODISCOVERY_LIMA_HOME")
+        if not self._dataset_paths:
+            raise ValueError("The Lima execution backend requires at least one dataset path")
+        if not self._cwd.is_dir():
+            raise ValueError(f"VM work directory does not exist: {self._cwd}")
+        missing_datasets = [path for path in self._dataset_paths if not path.is_file()]
+        if missing_datasets:
+            raise ValueError(f"VM dataset does not exist: {missing_datasets[0]}")
+        unsafe_roots = [
+            root
+            for root in (*self._dataset_roots, self._work_root)
+            if root in _FORBIDDEN_MOUNT_ROOTS
+        ]
+        if unsafe_roots:
+            raise ValueError(f"Refusing unsafe VM mount root: {unsafe_roots[0]}")
+
+    @property
+    def _work_root(self) -> Path:
+        return self._cwd.parent if self._cwd.name.startswith("thread_") else self._cwd
+
+    @property
+    def _dataset_roots(self) -> tuple[Path, ...]:
+        roots: list[Path] = []
+        for path in sorted({path.parent for path in self._dataset_paths}):
+            if not any(path.is_relative_to(root) for root in roots):
+                roots.append(path)
+        return tuple(roots)
+
+    @property
+    def _environment(self) -> dict[str, str]:
+        assert self._lima_home is not None
+        return {**os.environ, "LIMA_HOME": str(self._lima_home)}
+
+    @property
+    def _mount_marker(self) -> Path:
+        assert self._lima_home is not None
+        return self._lima_home / self._instance_name / ".autodiscovery-mounts.json"
+
+    @staticmethod
+    def _systemd_path(path: str | Path) -> str:
+        return json.dumps(str(path))
+
+    def _run_lima(
+        self,
+        arguments: list[str],
+        *,
+        input_text: str | None = None,
+        check: bool = True,
+        timeout: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [self._lima_path, *arguments],
+            input=input_text,
+            capture_output=True,
+            text=True,
+            env=self._environment,
+            check=check,
+            timeout=timeout,
+        )
+
+    def _ensure_mounts(self) -> None:
+        expected = {
+            "dataset_roots": [str(path) for path in self._dataset_roots],
+            "work_root": str(self._work_root),
+        }
+        with _VM_LOCK:
+            try:
+                current = json.loads(self._mount_marker.read_text(encoding="utf-8"))
+            except (FileNotFoundError, json.JSONDecodeError):
+                current = None
+            if current == expected:
+                status = self._run_lima(
+                    ["list", self._instance_name, "--json"], check=False
+                )
+                normalized_status = status.stdout.replace(" ", "")
+                if status.returncode == 0 and '"status":"Running"' in normalized_status:
+                    return
+
+            self._run_lima(["stop", self._instance_name], check=False, timeout=120)
+            mounts = [str(path) for path in self._dataset_roots]
+            mounts.append(f"{self._work_root}:w")
+            self._run_lima(
+                [
+                    "edit",
+                    self._instance_name,
+                    "--tty=false",
+                    f"--mount-only={','.join(mounts)}",
+                    "--mount-type=virtiofs",
+                ],
+                timeout=120,
+            )
+            self._run_lima(["start", self._instance_name], timeout=300)
+            self._mount_marker.parent.mkdir(parents=True, exist_ok=True)
+            self._mount_marker.write_text(json.dumps(expected, indent=2), encoding="utf-8")
+
+    def run_cell(
+        self,
+        code_str: str,
+        *,
+        use_subprocess: bool = False,
+        timeout_s: float | None = None,
+        allow_mime: Iterable[str] | None = None,
+        matplotlib_backend: str | None = ExecutionConfig.matplotlib_backend,
+    ) -> dict[str, Any]:
+        """Execute one code cell inside a transient no-network guest service."""
+        self._ensure_mounts()
+        timeout_s = timeout_s or 30 * 60
+        execution_id = uuid.uuid4().hex
+        workspace = f"/run/autodiscovery/{execution_id}"
+        guest_cwd = f"{workspace}/thread"
+        runtime_cache = self._cwd / ".runtime-cache"
+        runtime_cache.mkdir(parents=True, exist_ok=True)
+
+        setup = self._run_lima(
+            [
+                "shell",
+                self._instance_name,
+                "--",
+                "sudo",
+                "mkdir",
+                "-p",
+                guest_cwd,
+            ]
+        )
+        del setup
+
+        systemd_arguments = [
+            "shell",
+            self._instance_name,
+            "--",
+            "sudo",
+            "systemd-run",
+            "--quiet",
+            "--wait",
+            "--pipe",
+            "--collect",
+            "--unit",
+            f"autodiscovery-{execution_id}",
+            "--property",
+            "User=lima",
+            "--property",
+            "Group=lima",
+            "--property",
+            "PrivateNetwork=yes",
+            "--property",
+            "RestrictAddressFamilies=AF_UNIX",
+            "--property",
+            "NoNewPrivileges=yes",
+            "--property",
+            "ProtectSystem=strict",
+            "--property",
+            "ProtectHome=yes",
+            "--property",
+            "ProtectKernelTunables=yes",
+            "--property",
+            "ProtectKernelModules=yes",
+            "--property",
+            "ProtectKernelLogs=yes",
+            "--property",
+            "ProtectControlGroups=yes",
+            "--property",
+            "ProtectClock=yes",
+            "--property",
+            "ProtectHostname=yes",
+            "--property",
+            f"ReadWritePaths={guest_cwd}",
+            "--property",
+            "PrivateTmp=yes",
+            "--property",
+            "RestrictSUIDSGID=yes",
+            "--property",
+            "LockPersonality=yes",
+            "--property",
+            "RestrictRealtime=yes",
+            "--property",
+            "DevicePolicy=closed",
+            "--property",
+            "UMask=0077",
+            "--property",
+            "TasksMax=2048",
+            "--property",
+            "LimitNOFILE=4096",
+            "--property",
+            "MemorySwapMax=0",
+            "--property",
+            "MemoryMax=90%",
+            "--property",
+            "CapabilityBoundingSet=",
+            "--property",
+            f"RuntimeMaxSec={int(timeout_s)}",
+            "--property",
+            f"InaccessiblePaths={self._systemd_path(self._work_root)}",
+            "--property",
+            f"BindPaths={self._systemd_path(self._cwd)}:{self._systemd_path(guest_cwd)}",
+            "--property",
+            f"WorkingDirectory={guest_cwd}",
+            "--setenv",
+            f"IPYTHONDIR={guest_cwd}/.runtime-cache/ipython",
+            "--setenv",
+            f"MPLCONFIGDIR={guest_cwd}/.runtime-cache/matplotlib",
+            "--setenv",
+            f"XDG_CACHE_HOME={guest_cwd}/.runtime-cache/xdg",
+        ]
+        for dataset_root in self._dataset_roots:
+            systemd_arguments.extend(
+                [
+                    "--property",
+                    f"InaccessiblePaths={self._systemd_path(dataset_root)}",
+                ]
+            )
+        for dataset_path in self._dataset_paths:
+            target = f"{workspace}/{dataset_path.name}"
+            systemd_arguments.extend(
+                [
+                    "--property",
+                    "BindReadOnlyPaths="
+                    f"{self._systemd_path(dataset_path)}:{self._systemd_path(target)}",
+                ]
+            )
+        systemd_arguments.extend([self._guest_python, "-c", _SANDBOX_RUNNER])
+
+        payload = {
+            "code_str": code_str,
+            "use_subprocess": use_subprocess,
+            "timeout_s": None,
+            "allow_mime": list(allow_mime) if allow_mime is not None else None,
+            "matplotlib_backend": matplotlib_backend,
+        }
+        try:
+            result = self._run_lima(
+                systemd_arguments,
+                input_text=json.dumps(payload),
+                check=False,
+                timeout=timeout_s + 60,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "stdout": "",
+                "stderr": "",
+                "rich_outputs": [],
+                "success": False,
+                "error": {
+                    "type": "TimeoutError",
+                    "message": f"VM execution timed out after {timeout_s}s",
+                    "traceback": "",
+                },
+            }
+        finally:
+            self._run_lima(
+                ["shell", self._instance_name, "--", "sudo", "rm", "-rf", workspace],
+                check=False,
+            )
+
+        try:
+            parsed = json.loads(result.stdout) if result.stdout.strip() else {}
+        except json.JSONDecodeError:
+            return {
+                "stdout": "",
+                "stderr": result.stderr,
+                "rich_outputs": [],
+                "success": False,
+                "error": {
+                    "type": "RuntimeError",
+                    "message": "VM subprocess output was not valid JSON.",
+                    "traceback": result.stdout,
+                },
+            }
+        if result.stderr:
+            parsed["stderr"] = f"{parsed.get('stderr', '')}{result.stderr}"
+        return parsed

--- a/packages/code_execution/src/code_execution/lima_backend.py
+++ b/packages/code_execution/src/code_execution/lima_backend.py
@@ -95,6 +95,63 @@ class LimaIPythonBackend:
     def _systemd_path(path: str | Path) -> str:
         return json.dumps(str(path))
 
+    def _service_diagnostics(self, execution_id: str) -> str:
+        """Return a bounded journal excerpt for a failed transient service."""
+        try:
+            journal = self._run_lima(
+                [
+                    "shell",
+                    self._instance_name,
+                    "--",
+                    "sudo",
+                    "journalctl",
+                    "--no-pager",
+                    "--unit",
+                    f"autodiscovery-{execution_id}.service",
+                    "--lines",
+                    "40",
+                    "--output",
+                    "cat",
+                ],
+                check=False,
+                timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ""
+
+        output = "\n".join(part for part in (journal.stdout, journal.stderr) if part)
+        return output[-8_000:]
+
+    def _service_failure_result(
+        self,
+        *,
+        execution_id: str,
+        result: subprocess.CompletedProcess[str],
+        message: str,
+        raw_stdout: str = "",
+    ) -> dict[str, Any]:
+        """Normalize a systemd-run failure into the code-execution result contract."""
+        diagnostics = [f"systemd-run exit code: {result.returncode}"]
+        if result.stderr:
+            diagnostics.append(f"systemd-run stderr:\n{result.stderr[-8_000:]}")
+        journal = self._service_diagnostics(execution_id)
+        if journal:
+            diagnostics.append(f"systemd journal:\n{journal}")
+        if raw_stdout:
+            diagnostics.append(f"systemd-run stdout:\n{raw_stdout[-8_000:]}")
+        detail = "\n\n".join(diagnostics)
+        return {
+            "stdout": "",
+            "stderr": result.stderr,
+            "rich_outputs": [],
+            "success": False,
+            "error": {
+                "type": "LimaServiceError",
+                "message": message,
+                "traceback": detail,
+            },
+        }
+
     def _run_lima(
         self,
         arguments: list[str],
@@ -165,6 +222,8 @@ class LimaIPythonBackend:
         guest_cwd = f"{workspace}/thread"
         runtime_cache = self._cwd / ".runtime-cache"
         runtime_cache.mkdir(parents=True, exist_ok=True)
+        result_file = runtime_cache / f"{execution_id}.json"
+        guest_result_file = f"{guest_cwd}/.runtime-cache/{execution_id}.json"
 
         setup = self._run_lima(
             [
@@ -280,6 +339,7 @@ class LimaIPythonBackend:
             "timeout_s": None,
             "allow_mime": list(allow_mime) if allow_mime is not None else None,
             "matplotlib_backend": matplotlib_backend,
+            "result_path": guest_result_file,
         }
         try:
             result = self._run_lima(
@@ -306,20 +366,52 @@ class LimaIPythonBackend:
                 check=False,
             )
 
+        stdout = result.stdout or ""
+        if not stdout.strip():
+            try:
+                stdout = result_file.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                pass
         try:
-            parsed = json.loads(result.stdout) if result.stdout.strip() else {}
+            result_file.unlink()
+        except FileNotFoundError:
+            pass
+        if not stdout.strip():
+            message = (
+                "VM execution completed without a structured result. "
+                "The guest service returned no JSON output."
+            )
+            if result.returncode:
+                message = f"VM execution service failed before returning a result (exit {result.returncode})."
+            return self._service_failure_result(
+                execution_id=execution_id,
+                result=result,
+                message=message,
+            )
+
+        try:
+            parsed = json.loads(stdout)
         except json.JSONDecodeError:
-            return {
-                "stdout": "",
-                "stderr": result.stderr,
-                "rich_outputs": [],
-                "success": False,
-                "error": {
-                    "type": "RuntimeError",
-                    "message": "VM subprocess output was not valid JSON.",
-                    "traceback": result.stdout,
-                },
-            }
+            return self._service_failure_result(
+                execution_id=execution_id,
+                result=result,
+                message="VM execution service returned invalid JSON.",
+                raw_stdout=stdout,
+            )
+        if not isinstance(parsed, dict):
+            return self._service_failure_result(
+                execution_id=execution_id,
+                result=result,
+                message="VM execution service returned a non-object JSON result.",
+                raw_stdout=stdout,
+            )
+        if result.returncode:
+            return self._service_failure_result(
+                execution_id=execution_id,
+                result=result,
+                message=f"VM execution service exited with code {result.returncode}.",
+                raw_stdout=stdout,
+            )
         if result.stderr:
             parsed["stderr"] = f"{parsed.get('stderr', '')}{result.stderr}"
         return parsed

--- a/packages/code_execution/src/code_execution/process_backend.py
+++ b/packages/code_execution/src/code_execution/process_backend.py
@@ -29,8 +29,10 @@ _DEFAULT_SANDBOX_PACKAGES = [
 
 _SANDBOX_RUNNER = """\
 import json
+import os
 import sys
 import traceback
+from pathlib import Path
 
 from code_execution.ipython_session import ExecutionConfig, IPythonSession
 
@@ -65,6 +67,14 @@ def main() -> None:
             "success": False,
             "error": _format_error(exc),
         }
+    result_path = payload.get("result_path")
+    if result_path:
+        destination = Path(result_path)
+        temporary = destination.with_suffix(f"{destination.suffix}.tmp")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with temporary.open("w", encoding="utf-8") as output:
+            json.dump(result, output)
+        os.replace(temporary, destination)
     json.dump(result, sys.stdout)
 
 

--- a/packages/code_execution/tests/test_lima_backend.py
+++ b/packages/code_execution/tests/test_lima_backend.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from code_execution import LimaIPythonBackend
+
+
+def _backend(tmp_path: Path) -> tuple[LimaIPythonBackend, Path, Path, Path]:
+    lima_path = tmp_path / "limactl"
+    lima_path.touch()
+    lima_home = tmp_path / "lima-home"
+    source = tmp_path / "source" / "dataset.csv"
+    source.parent.mkdir()
+    source.write_text("value\n1\n", encoding="utf-8")
+    work = tmp_path / "work"
+    thread = work / "thread_1"
+    thread.mkdir(parents=True)
+    return (
+        LimaIPythonBackend(
+            cwd=str(thread),
+            dataset_paths=[str(source)],
+            lima_path=str(lima_path),
+            lima_home=str(lima_home),
+        ),
+        source,
+        work,
+        lima_home,
+    )
+
+
+def test_run_cell_uses_exact_mounts_and_hardened_service(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend, source, work, _ = _backend(tmp_path)
+    calls: list[tuple[list[str], dict[str, Any]]] = []
+    response = {
+        "stdout": "ok\n",
+        "stderr": "",
+        "rich_outputs": [],
+        "success": True,
+        "error": None,
+    }
+
+    def fake_run(arguments: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append((arguments, kwargs))
+        stdout = json.dumps(response) if "systemd-run" in arguments else ""
+        return subprocess.CompletedProcess(arguments, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("code_execution.lima_backend.subprocess.run", fake_run)
+
+    result = backend.run_cell("print('ok')", timeout_s=15)
+
+    assert result == response
+    edit = next(arguments for arguments, _ in calls if "edit" in arguments)
+    assert edit[1:3] == ["edit", "ad"]
+    assert f"--mount-only={source.parent},{work}:w" in edit
+    assert "--mount-type=virtiofs" in edit
+
+    service = next(arguments for arguments, _ in calls if "systemd-run" in arguments)
+    assert "PrivateNetwork=yes" in service
+    assert "RestrictAddressFamilies=AF_UNIX" in service
+    assert "NoNewPrivileges=yes" in service
+    assert "ProtectSystem=strict" in service
+    assert "ProtectHome=yes" in service
+    assert "ProtectKernelTunables=yes" in service
+    assert "ProtectKernelModules=yes" in service
+    assert "ProtectKernelLogs=yes" in service
+    assert "ProtectControlGroups=yes" in service
+    assert "ProtectClock=yes" in service
+    assert "ProtectHostname=yes" in service
+    assert "LockPersonality=yes" in service
+    assert "RestrictRealtime=yes" in service
+    assert "DevicePolicy=closed" in service
+    assert "UMask=0077" in service
+    assert "TasksMax=2048" in service
+    assert "LimitNOFILE=4096" in service
+    assert "MemorySwapMax=0" in service
+    assert "MemoryMax=90%" in service
+    assert "CapabilityBoundingSet=" in service
+    assert f"InaccessiblePaths={json.dumps(str(source.parent))}" in service
+    assert f"InaccessiblePaths={json.dumps(str(work))}" in service
+    assert f"BindPaths={json.dumps(str(work / 'thread_1'))}:" in " ".join(service)
+    assert f"BindReadOnlyPaths={json.dumps(str(source))}:" in " ".join(service)
+    assert all("/Users" not in value for value in service if value.startswith("WorkingDirectory="))
+
+
+def test_matching_running_vm_reuses_mounts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend, source, work, lima_home = _backend(tmp_path)
+    instance = lima_home / "ad"
+    instance.mkdir(parents=True)
+    (instance / ".autodiscovery-mounts.json").write_text(
+        json.dumps(
+            {
+                "dataset_roots": [str(source.parent)],
+                "work_root": str(work),
+            }
+        ),
+        encoding="utf-8",
+    )
+    calls: list[list[str]] = []
+    response = {
+        "stdout": "",
+        "stderr": "",
+        "rich_outputs": [],
+        "success": True,
+        "error": None,
+    }
+
+    def fake_run(arguments: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(arguments)
+        if "list" in arguments:
+            return subprocess.CompletedProcess(
+                arguments, 0, stdout='{"status": "Running"}', stderr=""
+            )
+        stdout = json.dumps(response) if "systemd-run" in arguments else ""
+        return subprocess.CompletedProcess(arguments, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("code_execution.lima_backend.subprocess.run", fake_run)
+
+    assert backend.run_cell("pass")["success"] is True
+    assert not any("edit" in arguments for arguments in calls)
+    assert not any("start" in arguments for arguments in calls)
+    assert not any("stop" in arguments for arguments in calls)
+
+
+def test_timeout_is_normalized(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    backend, _, _, _ = _backend(tmp_path)
+
+    def fake_run(arguments: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if "systemd-run" in arguments:
+            raise subprocess.TimeoutExpired(arguments, kwargs.get("timeout", 0))
+        return subprocess.CompletedProcess(arguments, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("code_execution.lima_backend.subprocess.run", fake_run)
+
+    result = backend.run_cell("pass", timeout_s=2)
+
+    assert result["success"] is False
+    assert result["error"]["type"] == "TimeoutError"
+    assert "2s" in result["error"]["message"]
+
+
+def test_invalid_vm_output_is_normalized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend, _, _, _ = _backend(tmp_path)
+
+    def fake_run(arguments: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        stdout = "not-json" if "systemd-run" in arguments else ""
+        return subprocess.CompletedProcess(arguments, 1, stdout=stdout, stderr="service failed")
+
+    monkeypatch.setattr("code_execution.lima_backend.subprocess.run", fake_run)
+
+    result = backend.run_cell("pass")
+
+    assert result["success"] is False
+    assert result["error"]["type"] == "RuntimeError"
+    assert result["error"]["traceback"] == "not-json"
+    assert result["stderr"] == "service failed"
+
+
+def test_unsafe_mount_root_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lima_path = tmp_path / "limactl"
+    lima_path.touch()
+    source = tmp_path / "source" / "dataset.csv"
+    source.parent.mkdir()
+    source.touch()
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.setattr(
+        "code_execution.lima_backend._FORBIDDEN_MOUNT_ROOTS", {source.parent}
+    )
+
+    with pytest.raises(ValueError, match="unsafe VM mount root"):
+        LimaIPythonBackend(
+            cwd=str(work),
+            dataset_paths=[str(source)],
+            lima_path=str(lima_path),
+            lima_home=str(tmp_path / "lima-home"),
+        )
+
+
+def test_systemd_paths_with_spaces_are_quoted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spaced_root = tmp_path / "dataset with spaces"
+    source = spaced_root / "source data.csv"
+    spaced_root.mkdir()
+    source.touch()
+    work = tmp_path / "work with spaces"
+    work.mkdir()
+    lima_path = tmp_path / "limactl"
+    lima_path.touch()
+    backend = LimaIPythonBackend(
+        cwd=str(work),
+        dataset_paths=[str(source)],
+        lima_path=str(lima_path),
+        lima_home=str(tmp_path / "lima-home"),
+    )
+    response = {
+        "stdout": "",
+        "stderr": "",
+        "rich_outputs": [],
+        "success": True,
+        "error": None,
+    }
+    calls: list[list[str]] = []
+
+    def fake_run(arguments: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(arguments)
+        stdout = json.dumps(response) if "systemd-run" in arguments else ""
+        return subprocess.CompletedProcess(arguments, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("code_execution.lima_backend.subprocess.run", fake_run)
+
+    assert backend.run_cell("pass")["success"] is True
+    service = next(arguments for arguments in calls if "systemd-run" in arguments)
+    assert f"InaccessiblePaths={json.dumps(str(spaced_root))}" in service
+    assert f"BindPaths={json.dumps(str(work))}:" in " ".join(service)
+    assert f"BindReadOnlyPaths={json.dumps(str(source))}:" in " ".join(service)

--- a/packages/code_execution/tests/test_lima_backend.py
+++ b/packages/code_execution/tests/test_lima_backend.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -161,9 +163,110 @@ def test_invalid_vm_output_is_normalized(
     result = backend.run_cell("pass")
 
     assert result["success"] is False
-    assert result["error"]["type"] == "RuntimeError"
-    assert result["error"]["traceback"] == "not-json"
+    assert result["error"]["type"] == "LimaServiceError"
+    assert "invalid JSON" in result["error"]["message"]
+    assert "systemd-run stdout:\nnot-json" in result["error"]["traceback"]
     assert result["stderr"] == "service failed"
+
+
+def test_empty_vm_output_is_reported_as_a_service_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend, _, _, _ = _backend(tmp_path)
+
+    def fake_run(arguments: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(arguments, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("code_execution.lima_backend.subprocess.run", fake_run)
+
+    result = backend.run_cell("pass")
+
+    assert result["success"] is False
+    assert result["error"]["type"] == "LimaServiceError"
+    assert "no JSON output" in result["error"]["message"]
+    assert "systemd-run exit code: 0" in result["error"]["traceback"]
+
+
+def test_result_file_recovers_a_dropped_vm_stdout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend, _, work, _ = _backend(tmp_path)
+    execution_id = "result-file-fallback"
+    response = {
+        "stdout": "recovered\n",
+        "stderr": "",
+        "rich_outputs": [],
+        "success": True,
+        "error": None,
+    }
+
+    class FixedUuid:
+        hex = execution_id
+
+    def fake_run(arguments: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if "systemd-run" in arguments:
+            result_path = work / "thread_1" / ".runtime-cache" / f"{execution_id}.json"
+            result_path.parent.mkdir(exist_ok=True)
+            result_path.write_text(json.dumps(response), encoding="utf-8")
+        return subprocess.CompletedProcess(arguments, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("code_execution.lima_backend.uuid.uuid4", lambda: FixedUuid())
+    monkeypatch.setattr("code_execution.lima_backend.subprocess.run", fake_run)
+
+    assert backend.run_cell("print('recovered')") == response
+    assert not (work / "thread_1" / ".runtime-cache" / f"{execution_id}.json").exists()
+
+
+def test_nonzero_vm_exit_includes_service_diagnostics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend, _, _, _ = _backend(tmp_path)
+
+    def fake_run(arguments: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if "journalctl" in arguments:
+            return subprocess.CompletedProcess(
+                arguments,
+                0,
+                stdout="Failed to set up mount namespacing",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(arguments, 226, stdout="", stderr="namespace failed")
+
+    monkeypatch.setattr("code_execution.lima_backend.subprocess.run", fake_run)
+
+    result = backend.run_cell("pass")
+
+    assert result["success"] is False
+    assert result["error"]["type"] == "LimaServiceError"
+    assert "exit 226" in result["error"]["message"]
+    assert "namespace failed" in result["error"]["traceback"]
+    assert "Failed to set up mount namespacing" in result["error"]["traceback"]
+
+
+def test_lima_integration_reports_missing_runner_result(tmp_path: Path) -> None:
+    """A guest exit before JSON serialization must not look like a timeout."""
+    lima_path = os.environ.get("AUTODISCOVERY_LIMA_PATH")
+    lima_home = os.environ.get("AUTODISCOVERY_LIMA_HOME")
+    if not lima_path or not lima_home:
+        pytest.skip("requires a configured Lima runtime")
+
+    source = tmp_path / "dataset.csv"
+    source.write_text("value\n1\n", encoding="utf-8")
+    work = tmp_path / "work" / "thread_integration"
+    work.mkdir(parents=True)
+    backend = LimaIPythonBackend(
+        cwd=str(work),
+        dataset_paths=[str(source)],
+        lima_path=lima_path,
+        lima_home=lima_home,
+    )
+
+    result = backend.run_cell("import os; os._exit(0)", timeout_s=60)
+
+    assert result["success"] is False
+    assert result["error"]["type"] == "LimaServiceError"
+    assert "no JSON output" in result["error"]["message"]
+    assert "systemd-run exit code: 0" in result["error"]["traceback"]
 
 
 def test_unsafe_mount_root_is_rejected(


### PR DESCRIPTION
## Summary
- Adds the Lima generated-code backend for local desktop execution.
- Preserves systemd service diagnostics and handles guest result transport through an atomic result-file fallback.
- Defers optional image-client imports so ordinary Lima executions do not require OpenAI.

## Validation
- Real installed-app Lima contract verified normal output, Python exceptions, and an exit-before-result failure.
- A full local discovery run completed successfully with five code cells and no false timeout.

## Stack
Depends on the local UI PR below it.