### PR TITLE
Update credit expiration date to December 31st, 2026

### DIFF
--- a/ui/src/app/components/CreditsChip.tsx
+++ b/ui/src/app/components/CreditsChip.tsx
@@ -66,7 +66,7 @@ export default function CreditsChip() {
                         </li>
                         <li>
                             <strong>Expiration:</strong> Credits are valid until{' '}
-                            <strong>July 31st, 2026</strong>.
+                            <strong>December 31st, 2026</strong>.
                         </li>
                     </ul>
 


### PR DESCRIPTION
## What
Change the credit expiration date shown in the AutoDiscovery **CreditsChip** popover from **July 31st, 2026** to **December 31st, 2026**.

## Why
Requested by Paul Sayre — the credit validity window is being extended. This updates the user-facing "Expiration: Credits are valid until …" copy in `ui/src/app/components/CreditsChip.tsx` to reflect the new date.

Note: this is display copy only. Production credit logic has no server-side expiry enforcement today, so this changes the stated policy text to match the new intent.

<!-- gas2own-origin: {"slack": {"channel": "C0BPAFV6274", "thread_ts": "1786730820.792779"}} -->