### PR TITLE
Cache credits endpoint and skip orphan metadata lookups

### DIFF
--- a/api/tests/test_credits.py
+++ b/api/tests/test_credits.py
@@ -21,6 +21,29 @@ def test_cached_user_credits_reuses_result_for_same_user():
     calculate.assert_called_once_with(userid="user", config=config)
 
 
+def test_cached_user_credits_reuses_result_for_equal_configs():
+    """Distinct but equal JobConfigs share one cache key, since JobConfig is frozen."""
+    expected = credits.UserCredits(granted=500, consumed=10, pending=5, available=485)
+
+    with patch.object(credits, "get_user_credits", return_value=expected) as calculate:
+        assert credits.get_cached_user_credits("user", JobConfig(bucket="bucket")) == expected
+        assert credits.get_cached_user_credits("user", JobConfig(bucket="bucket")) == expected
+
+    assert calculate.call_count == 1
+
+
+def test_cached_user_credits_is_scoped_by_config():
+    with patch.object(credits, "get_user_credits") as calculate:
+        calculate.side_effect = [
+            credits.UserCredits(500, 1, 0, 499),
+            credits.UserCredits(500, 2, 0, 498),
+        ]
+        assert credits.get_cached_user_credits("user", JobConfig(bucket="first")).consumed == 1
+        assert credits.get_cached_user_credits("user", JobConfig(bucket="second")).consumed == 2
+
+    assert calculate.call_count == 2
+
+
 def test_cached_user_credits_is_scoped_by_user():
     config = JobConfig(bucket="bucket", project_id="project")
 

--- a/api/tests/test_credits.py
+++ b/api/tests/test_credits.py
@@ -7,8 +7,7 @@ from utils import credits
 
 
 def setup_function():
-    credits._credits_cache.clear()
-    credits._credits_refresh_locks.clear()
+    credits._aggregate_user_credits.cache_clear()
 
 
 def test_cached_user_credits_reuses_result_for_same_user():
@@ -32,5 +31,26 @@ def test_cached_user_credits_is_scoped_by_user():
         ]
         assert credits.get_cached_user_credits("first", config).consumed == 1
         assert credits.get_cached_user_credits("second", config).consumed == 2
+
+    assert calculate.call_count == 2
+
+
+def test_cached_user_credits_expires_after_ttl():
+    config = JobConfig(bucket="bucket", project_id="project")
+
+    with (
+        patch.object(credits, "get_user_credits") as calculate,
+        patch.object(credits, "monotonic") as clock,
+    ):
+        calculate.side_effect = [
+            credits.UserCredits(500, 1, 0, 499),
+            credits.UserCredits(500, 2, 0, 498),
+        ]
+        clock.return_value = 0.0
+        assert credits.get_cached_user_credits("user", config).consumed == 1
+        clock.return_value = credits.CREDITS_CACHE_TTL_SECONDS / 2
+        assert credits.get_cached_user_credits("user", config).consumed == 1
+        clock.return_value = credits.CREDITS_CACHE_TTL_SECONDS
+        assert credits.get_cached_user_credits("user", config).consumed == 2
 
     assert calculate.call_count == 2

--- a/api/tests/test_credits.py
+++ b/api/tests/test_credits.py
@@ -1,0 +1,36 @@
+"""Tests for credit aggregation caching."""
+
+from unittest.mock import patch
+
+from autodiscovery_jobs import JobConfig
+from utils import credits
+
+
+def setup_function():
+    credits._credits_cache.clear()
+    credits._credits_refresh_locks.clear()
+
+
+def test_cached_user_credits_reuses_result_for_same_user():
+    config = JobConfig(bucket="bucket", project_id="project")
+    expected = credits.UserCredits(granted=500, consumed=10, pending=5, available=485)
+
+    with patch.object(credits, "get_user_credits", return_value=expected) as calculate:
+        assert credits.get_cached_user_credits("user", config) == expected
+        assert credits.get_cached_user_credits("user", config) == expected
+
+    calculate.assert_called_once_with(userid="user", config=config)
+
+
+def test_cached_user_credits_is_scoped_by_user():
+    config = JobConfig(bucket="bucket", project_id="project")
+
+    with patch.object(credits, "get_user_credits") as calculate:
+        calculate.side_effect = [
+            credits.UserCredits(500, 1, 0, 499),
+            credits.UserCredits(500, 2, 0, 498),
+        ]
+        assert credits.get_cached_user_credits("first", config).consumed == 1
+        assert credits.get_cached_user_credits("second", config).consumed == 2
+
+    assert calculate.call_count == 2

--- a/api/user/user_api.py
+++ b/api/user/user_api.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, current_app, jsonify, request
 from utils.auth import get_auth_provider, requires_auth
-from utils.credits import get_user_credits
+from utils.credits import get_cached_user_credits
 
 # Import autodiscovery_jobs when available
 try:
@@ -55,7 +55,7 @@ def create() -> Blueprint:
 
         try:
             job_manager = get_job_manager()
-            user_credits = get_user_credits(userid=user_id, config=job_manager.config)
+            user_credits = get_cached_user_credits(userid=user_id, config=job_manager.config)
 
             return jsonify(
                 {

--- a/api/utils/credits.py
+++ b/api/utils/credits.py
@@ -28,7 +28,6 @@ Example usage:
 
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import astuple
 from functools import lru_cache
 from time import monotonic
 from typing import Any, NamedTuple
@@ -306,15 +305,14 @@ def get_user_credits(userid: str, config: JobConfig | None = None) -> UserCredit
 
 
 @lru_cache(maxsize=CREDITS_CACHE_MAX_ENTRIES)
-def _aggregate_user_credits(
-    userid: str, config_fields: tuple[Any, ...], _ttl_bucket: int
-) -> UserCredits:
+def _aggregate_user_credits(userid: str, config: JobConfig, _ttl_bucket: int) -> UserCredits:
     """Cache key holder for :func:`get_cached_user_credits`.
 
-    ``config_fields`` is a hashable ``astuple`` of the JobConfig; ``_ttl_bucket``
-    changes every ``CREDITS_CACHE_TTL_SECONDS`` so entries age out.
+    ``JobConfig`` is a frozen dataclass, so it is hashable and usable as part of
+    the cache key directly; ``_ttl_bucket`` changes every
+    ``CREDITS_CACHE_TTL_SECONDS`` so entries age out.
     """
-    return get_user_credits(userid=userid, config=JobConfig(*config_fields))
+    return get_user_credits(userid=userid, config=config)
 
 
 def get_cached_user_credits(userid: str, config: JobConfig | None = None) -> UserCredits:
@@ -325,7 +323,7 @@ def get_cached_user_credits(userid: str, config: JobConfig | None = None) -> Use
     """
     config = config or JobConfig()
     ttl_bucket = int(monotonic() // CREDITS_CACHE_TTL_SECONDS)
-    return _aggregate_user_credits(userid, astuple(config), ttl_bucket)
+    return _aggregate_user_credits(userid, config, ttl_bucket)
 
 
 def can_start_experiments(n_experiments: int, userid: str, config: JobConfig | None = None) -> bool:

--- a/api/utils/credits.py
+++ b/api/utils/credits.py
@@ -28,10 +28,10 @@ Example usage:
 
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from threading import Lock
+from dataclasses import astuple
+from functools import lru_cache
 from time import monotonic
 from typing import Any, NamedTuple
-from weakref import WeakValueDictionary
 
 from autodiscovery_jobs import JobConfig
 from autodiscovery_jobs.gcs import (
@@ -55,6 +55,9 @@ DEFAULT_EXPERIMENT_LIMIT = 500
 # deliberately short so the UI remains current while repeated reads share one
 # GCS aggregation. Credit checks before run submission bypass this cache.
 CREDITS_CACHE_TTL_SECONDS = 5.0
+
+# Cap on distinct (user, config) entries kept per worker process.
+CREDITS_CACHE_MAX_ENTRIES = 512
 
 
 class JobStats(NamedTuple):
@@ -87,13 +90,6 @@ class UserCredits(NamedTuple):
     consumed: int
     pending: int
     available: int
-
-
-_credits_cache: dict[tuple[str, str, str | None], tuple[float, UserCredits]] = {}
-_credits_cache_lock = Lock()
-_credits_refresh_locks: WeakValueDictionary[tuple[str, str, str | None], Lock] = (
-    WeakValueDictionary()
-)
 
 
 class InsufficientCreditsError(Exception):
@@ -309,36 +305,27 @@ def get_user_credits(userid: str, config: JobConfig | None = None) -> UserCredit
     )
 
 
+@lru_cache(maxsize=CREDITS_CACHE_MAX_ENTRIES)
+def _aggregate_user_credits(
+    userid: str, config_fields: tuple[Any, ...], _ttl_bucket: int
+) -> UserCredits:
+    """Cache key holder for :func:`get_cached_user_credits`.
+
+    ``config_fields`` is a hashable ``astuple`` of the JobConfig; ``_ttl_bucket``
+    changes every ``CREDITS_CACHE_TTL_SECONDS`` so entries age out.
+    """
+    return get_user_credits(userid=userid, config=JobConfig(*config_fields))
+
+
 def get_cached_user_credits(userid: str, config: JobConfig | None = None) -> UserCredits:
     """Return a short-lived, per-user cached credits summary.
 
-    Concurrent cache misses for the same user are coalesced into one GCS
-    aggregation. Callers that enforce credit limits must use
-    :func:`get_user_credits` directly so authorization always uses fresh data.
+    Callers that enforce credit limits must use :func:`get_user_credits`
+    directly so authorization always uses fresh data.
     """
     config = config or JobConfig()
-    cache_key = (userid, config.bucket, config.project_id)
-
-    with _credits_cache_lock:
-        cached = _credits_cache.get(cache_key)
-        if cached is not None and cached[0] > monotonic():
-            return cached[1]
-        refresh_lock = _credits_refresh_locks.setdefault(cache_key, Lock())
-
-    with refresh_lock:
-        # Another request may have populated the cache while this one waited.
-        with _credits_cache_lock:
-            cached = _credits_cache.get(cache_key)
-            if cached is not None and cached[0] > monotonic():
-                return cached[1]
-
-        credits = get_user_credits(userid=userid, config=config)
-        with _credits_cache_lock:
-            _credits_cache[cache_key] = (
-                monotonic() + CREDITS_CACHE_TTL_SECONDS,
-                credits,
-            )
-        return credits
+    ttl_bucket = int(monotonic() // CREDITS_CACHE_TTL_SECONDS)
+    return _aggregate_user_credits(userid, astuple(config), ttl_bucket)
 
 
 def can_start_experiments(n_experiments: int, userid: str, config: JobConfig | None = None) -> bool:

--- a/api/utils/credits.py
+++ b/api/utils/credits.py
@@ -28,13 +28,16 @@ Example usage:
 
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from threading import Lock
+from time import monotonic
 from typing import Any, NamedTuple
+from weakref import WeakValueDictionary
 
 from autodiscovery_jobs import JobConfig
 from autodiscovery_jobs.gcs import (
     count_experiment_results,
     get_job_args,
-    get_metadata,
+    get_metadata_or_none,
     list_user_jobs,
 )
 from autodiscovery_jobs.run_details import get_run_details
@@ -47,6 +50,11 @@ DEFAULT_CREDITS_GRANTED = 500
 
 # Max number of experiments that can run in a single job
 DEFAULT_EXPERIMENT_LIMIT = 500
+
+# The credits display is polled frequently by every open browser tab. Keep this
+# deliberately short so the UI remains current while repeated reads share one
+# GCS aggregation. Credit checks before run submission bypass this cache.
+CREDITS_CACHE_TTL_SECONDS = 5.0
 
 
 class JobStats(NamedTuple):
@@ -79,6 +87,13 @@ class UserCredits(NamedTuple):
     consumed: int
     pending: int
     available: int
+
+
+_credits_cache: dict[tuple[str, str, str | None], tuple[float, UserCredits]] = {}
+_credits_cache_lock = Lock()
+_credits_refresh_locks: WeakValueDictionary[tuple[str, str, str | None], Lock] = (
+    WeakValueDictionary()
+)
 
 
 class InsufficientCreditsError(Exception):
@@ -174,7 +189,7 @@ def get_job_stats(userid: str, jobid: str, config: JobConfig | None = None) -> J
     """
     config = config or JobConfig()
 
-    metadata = get_metadata(userid=userid, jobid=jobid, config=config)
+    metadata = get_metadata_or_none(userid=userid, jobid=jobid, config=config)
     if metadata is None:
         return None
 
@@ -292,6 +307,38 @@ def get_user_credits(userid: str, config: JobConfig | None = None) -> UserCredit
         pending=total_pending,
         available=available,
     )
+
+
+def get_cached_user_credits(userid: str, config: JobConfig | None = None) -> UserCredits:
+    """Return a short-lived, per-user cached credits summary.
+
+    Concurrent cache misses for the same user are coalesced into one GCS
+    aggregation. Callers that enforce credit limits must use
+    :func:`get_user_credits` directly so authorization always uses fresh data.
+    """
+    config = config or JobConfig()
+    cache_key = (userid, config.bucket, config.project_id)
+
+    with _credits_cache_lock:
+        cached = _credits_cache.get(cache_key)
+        if cached is not None and cached[0] > monotonic():
+            return cached[1]
+        refresh_lock = _credits_refresh_locks.setdefault(cache_key, Lock())
+
+    with refresh_lock:
+        # Another request may have populated the cache while this one waited.
+        with _credits_cache_lock:
+            cached = _credits_cache.get(cache_key)
+            if cached is not None and cached[0] > monotonic():
+                return cached[1]
+
+        credits = get_user_credits(userid=userid, config=config)
+        with _credits_cache_lock:
+            _credits_cache[cache_key] = (
+                monotonic() + CREDITS_CACHE_TTL_SECONDS,
+                credits,
+            )
+        return credits
 
 
 def can_start_experiments(n_experiments: int, userid: str, config: JobConfig | None = None) -> bool:

--- a/api/utils/credits.py
+++ b/api/utils/credits.py
@@ -311,6 +311,12 @@ def _aggregate_user_credits(userid: str, config: JobConfig, _ttl_bucket: int) ->
     ``JobConfig`` is a frozen dataclass, so it is hashable and usable as part of
     the cache key directly; ``_ttl_bucket`` changes every
     ``CREDITS_CACHE_TTL_SECONDS`` so entries age out.
+
+    There is deliberately no in-flight lock around the miss: ``start.sh`` runs
+    gunicorn sync workers with no ``--threads``, so a process handles one
+    request at a time and has nothing to coalesce. Concurrency here is between
+    the 10 worker processes, which no in-process lock can serialise. Revisit if
+    the server ever moves to threaded or async workers.
     """
     return get_user_credits(userid=userid, config=config)
 

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/config.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 # How many days uploaded datasets are retained before the cleanup cron deletes
 # them from GCS.  Both the cleanup script and the API's expiry estimate read
@@ -11,9 +11,14 @@ from dataclasses import dataclass
 DATASET_EXPIRY_DAYS: int = 7
 
 
-@dataclass
+@dataclass(frozen=True)
 class JobConfig:
-    """Configuration for Cloud Run job management."""
+    """Configuration for Cloud Run job management.
+
+    Frozen so instances are hashable and can be used directly as cache keys
+    (see ``api/utils/credits.py``); use :func:`dataclasses.replace` to derive a
+    modified copy.
+    """
 
     # GCS Configuration
     bucket: str = "autodiscovery"
@@ -70,9 +75,6 @@ class JobConfig:
             modal_bucket_secret=os.environ.get("MODAL_BUCKET_SECRET", cls.modal_bucket_secret),
         )
 
-        # Apply overrides
-        for key, value in overrides.items():
-            if hasattr(config, key):
-                setattr(config, key, value)
-
-        return config
+        # Apply overrides (unknown keys are ignored)
+        known = {key: value for key, value in overrides.items() if hasattr(config, key)}
+        return replace(config, **known) if known else config

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/gcs.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/gcs.py
@@ -690,6 +690,28 @@ def upload_job_args(
         raise GCSError(f"Failed to save job args: {e}")
 
 
+def get_metadata_or_none(
+    userid: str, jobid: str, config: JobConfig | None = None
+) -> dict[str, Any] | None:
+    """Download metadata.json, returning ``None`` when it is absent.
+
+    This is the single-round-trip form for callers, such as credit
+    aggregation, where a job prefix without metadata is expected to be
+    skipped rather than distinguished from an entirely absent job.
+    """
+    config = config or JobConfig()
+    client = get_storage_client(config.project_id)
+    bucket = client.bucket(config.bucket)
+    blob_path = f"users/{userid}/jobs/{jobid}/metadata.json"
+
+    try:
+        return json.loads(bucket.blob(blob_path).download_as_text())
+    except NotFound:
+        return None
+    except Exception as e:
+        raise GCSError(f"Failed to download metadata: {e}") from e
+
+
 def get_metadata(userid: str, jobid: str, config: JobConfig | None = None) -> dict[str, Any]:
     """Download and parse metadata.json from job directory.
 
@@ -707,27 +729,16 @@ def get_metadata(userid: str, jobid: str, config: JobConfig | None = None) -> di
     """
     config = config or JobConfig()
 
-    client = get_storage_client(config.project_id)
-    bucket = client.bucket(config.bucket)
-
-    blob_path = f"users/{userid}/jobs/{jobid}/metadata.json"
-
     # Download directly instead of pre-checking existence with a separate list
     # request. On a miss we fall back to job_exists() only to preserve the
     # historical exception contract (JobNotFoundError vs GCSError); the common
     # case where metadata.json exists costs a single round-trip.
-    try:
-        blob = bucket.blob(blob_path)
-        metadata_str = blob.download_as_text()
-        return json.loads(metadata_str)
-    except NotFound:
-        if not job_exists(userid, jobid, config):
-            raise JobNotFoundError(f"Job {jobid} not found for user {userid}") from None
-        raise GCSError(
-            f"Failed to download metadata: metadata.json not found for job {jobid}"
-        ) from None
-    except Exception as e:
-        raise GCSError(f"Failed to download metadata: {e}")
+    metadata = get_metadata_or_none(userid, jobid, config)
+    if metadata is not None:
+        return metadata
+    if not job_exists(userid, jobid, config):
+        raise JobNotFoundError(f"Job {jobid} not found for user {userid}")
+    raise GCSError(f"Failed to download metadata: metadata.json not found for job {jobid}")
 
 
 def get_job_results(userid: str, jobid: str, config: JobConfig | None = None) -> list[str]:

--- a/packages/autodiscovery_jobs/tests/test_config.py
+++ b/packages/autodiscovery_jobs/tests/test_config.py
@@ -1,0 +1,33 @@
+"""Tests for JobConfig construction, overrides, and hashability."""
+
+import pytest
+from autodiscovery_jobs.config import JobConfig
+
+
+def test_config_is_hashable_and_value_equal():
+    """Frozen dataclass: equal-valued instances hash alike, so they share a cache key."""
+    first = JobConfig(bucket="bucket", project_id="project")
+    second = JobConfig(bucket="bucket", project_id="project")
+
+    assert first == second
+    assert hash(first) == hash(second)
+    assert len({first, second}) == 1
+    assert {first: "value"}[second] == "value"
+
+
+def test_config_is_immutable():
+    config = JobConfig(bucket="bucket")
+
+    with pytest.raises(AttributeError):
+        config.bucket = "other"  # type: ignore[misc]
+
+
+def test_from_env_applies_known_overrides_and_ignores_unknown(monkeypatch):
+    for var in ("GCS_BUCKET", "AUTODISCOVERY_BUCKET", "GCP_PROJECT", "GCP_REGION"):
+        monkeypatch.delenv(var, raising=False)
+
+    config = JobConfig.from_env(bucket="custom-bucket", not_a_field="ignored")
+
+    assert config.bucket == "custom-bucket"
+    assert config.region == JobConfig.region
+    assert not hasattr(config, "not_a_field")

--- a/packages/autodiscovery_jobs/tests/test_gcs.py
+++ b/packages/autodiscovery_jobs/tests/test_gcs.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from autodiscovery_jobs import gcs
 from autodiscovery_jobs.exceptions import JobAlreadyExistsError, JobNotFoundError
+from google.cloud.exceptions import NotFound
 
 
 def test_parse_gcs_path():
@@ -69,6 +70,19 @@ def test_job_exists(mock_config, mock_storage_client):
     # Job doesn't exist
     bucket.list_blobs.return_value = iter([])
     assert gcs.job_exists("testuser", "job2", mock_config) is False
+
+
+def test_get_metadata_or_none_skips_existence_check_on_missing_metadata(
+    mock_config, mock_storage_client
+):
+    """Credit aggregation should spend one request on orphaned job prefixes."""
+    _, bucket = mock_storage_client
+    bucket.blob.return_value.download_as_text.side_effect = NotFound("missing")
+
+    with patch("autodiscovery_jobs.gcs.job_exists") as exists:
+        assert gcs.get_metadata_or_none("testuser", "orphan", mock_config) is None
+
+    exists.assert_not_called()
 
 
 def test_create_job_directory(mock_config, mock_storage_client):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,9 @@ docs = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["packages"]
+testpaths = ["packages", "api/tests"]
 pythonpath = [
+    "api",
     "packages/code_execution/src",
     "packages/agents/src",
     "packages/autodiscovery/src",


### PR DESCRIPTION
## Summary

- cache `/api/user/me/credits` results for five seconds per user, using stdlib `functools.lru_cache` keyed on a TTL bucket
- keep run-submission credit validation uncached so authorization always uses fresh usage
- skip orphaned job prefixes after a single missing-metadata request instead of issuing a redundant `job_exists()` lookup

## Validation

- `17 passed`: focused credits and GCS tests
- `154 passed, 1 skipped`: full suite excluding `packages/code_execution` (its subprocess tests time out under the dispatcher runtime)
- `ruff check` on the changed files reports only findings that pre-date this branch (`D107`, one `E501` in untouched code)

Closes #75.

Suggested-by: @dirkraft

<!-- gas2own-origin: {"slack": {"channel": "C0A7KSC7GR4", "thread_ts": "1788299202.514219"}} -->
