### PR TITLE
Release 1.0.0: changelog and upgrade instructions for litellm model naming

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,6 +15,10 @@ jobs:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
 
+    # Split from the release job below so neither token carries the other's
+    # authority. These steps run third-party code -- each package's build
+    # backend, and the publish action on a moving tag -- so this token must
+    # not be able to write to the repo.
     permissions:
       id-token: write  # Required for trusted publishing
       contents: read   # Required to checkout the repo
@@ -58,3 +62,35 @@ jobs:
           packages-dir: dist/asta-autodiscovery
           print-hash: true
 
+  # PyPI renders only the current long description, so a GitHub release is the
+  # only place per-version notes live and the only thing watchers can subscribe
+  # to. Gated on publish, so a release cannot appear for a version that never
+  # reached PyPI.
+  release:
+    name: Create GitHub release
+    needs: publish
+    runs-on: ubuntu-latest
+
+    # The only scope this job needs. No id-token, so it cannot reach PyPI.
+    permissions:
+      contents: write
+
+    steps:
+      # No checkout needed: gh works against the API given --repo, and the body
+      # links the tag's CHANGELOG.md rather than reading it off disk.
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          cat > release-notes.md <<EOF
+          Published to PyPI: [asta-autodiscovery ${VERSION#v}](https://pypi.org/project/asta-autodiscovery/${VERSION#v}/)
+
+          Release notes, including breaking changes: [CHANGELOG.md](https://github.com/$REPO/blob/$VERSION/CHANGELOG.md)
+          EOF
+          gh release create "$VERSION" \
+            --repo "$REPO" \
+            --title "$VERSION" \
+            --verify-tag \
+            --notes-file release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,237 @@
+# Changelog
+
+All notable changes to the published packages — [`asta-autodiscovery`][pypi]
+(the `auto-discovery` CLI), `asta-autodiscovery-modal`, and
+`asta-code-execution` — are recorded here. This project follows
+[Semantic Versioning](https://semver.org/).
+
+[pypi]: https://pypi.org/project/asta-autodiscovery/
+
+## 1.0.0
+
+First release of the litellm-based model layer ([#67], [#68]). Every model call
+in the CLI now goes through [litellm](https://docs.litellm.ai/), which owns
+provider routing, credentials, request shaping and wire formats. The
+user-visible consequence is that **model flags now name their provider**, and
+**Vertex AI authenticates through Application Default Credentials only**.
+
+Upgrading requires editing your command line. Start with
+**[Standalone CLI → Selecting models](docs/autodiscovery/standalone.md#selecting-models)**;
+everything below is the summary.
+
+### Breaking: model flags require a `<provider>/<model>` prefix
+
+`--model`, `--belief_model`, `--vision_model` and `--embedding_model` now take
+[litellm's](https://docs.litellm.ai/docs/providers) qualified naming, with
+snake_case provider slugs. A bare model name is rejected at startup.
+
+```sh
+# 0.2.x
+auto-discovery --model gemini-3.1-pro-preview ...
+
+# 1.0.0
+auto-discovery --model vertex_ai/gemini-3.7-flash ...
+```
+
+The prefix is required rather than inferred. A bare name is genuinely
+ambiguous — `claude-haiku-4.5` is Anthropic direct or GitHub Copilot depending
+on who you ask — and resolving one means asking litellm, which triggers
+device-flow auth for some providers. An unqualified name fails immediately with
+the qualified form to use:
+
+```
+'gemini-3.7-flash' is missing a provider. Model names are litellm-qualified
+as <provider>/<model>, e.g. vertex_ai/gemini-3.7-flash or openai/gemini-3.7-flash.
+```
+
+`google/<model>` is also rejected. That was Vertex's OpenAI-compatible wire
+prefix, never a litellm provider slug — use `vertex_ai/<model>`.
+
+Any of litellm's ~149 providers may be named; there is no allow-list. The three
+this project configures credentials for and tests are `vertex_ai`, `openai` and
+`github_copilot`. Naming another means supplying its credentials yourself, per
+litellm's env-var conventions.
+
+Because the provider travels with each flag, one run can mix providers:
+
+```sh
+auto-discovery \
+    --model github_copilot/claude-haiku-4.5 \
+    --vision_model vertex_ai/gemini-3.7-flash \
+    ...
+```
+
+### Breaking: Vertex AI requires Application Default Credentials
+
+Raw bearer tokens are gone. `VERTEX_ACCESS_TOKEN`, `GOOGLE_OAUTH_ACCESS_TOKEN`
+and `VERTEX_OPENAI_BASE_URL` are no longer read; litellm's `vertex_ai`
+transport authenticates via `google.auth`. Use either a service-account key or
+local user credentials:
+
+```sh
+export VERTEX_PROJECT_ID=your-gcp-project
+export VERTEX_LOCATION=global                          # optional, defaults to global
+
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json  # service account
+# ...or, for local development:
+gcloud auth application-default login
+```
+
+`VERTEX_PROJECT_ID` and `VERTEX_LOCATION` keep working — they are mapped onto
+litellm's `vertex_project` / `vertex_location` — so existing deployment config
+needs no change beyond credentials. `OPENAI_API_KEY` is unchanged.
+
+### Breaking: default models changed
+
+| Flag | 0.2.x default | 1.0.0 default |
+| --- | --- | --- |
+| `--model` | `gemini-3.1-pro-preview` | `vertex_ai/gemini-3.7-flash` |
+| `--belief_model` | `gemini-3-flash-preview` | `vertex_ai/gemini-3.7-flash` |
+| `--vision_model` | `gemini-3.1-pro-preview` | `vertex_ai/gemini-3.7-flash` |
+| `--embedding_model` | (not a flag; hardcoded `text-embedding-3-large`) | `openai/text-embedding-3-large` |
+
+Runs that relied on the defaults will now use Gemini 3.7 Flash ([#71]).
+Expect different cost, latency and output than the 3.1 Pro preview default.
+
+### Added: GitHub Copilot as a provider
+
+Name it with the `github_copilot/` prefix; no extra install, litellm speaks it
+natively. On an interactive terminal litellm runs GitHub's device-code login on
+first use and caches the token itself. For non-interactive runs, pre-seed it:
+
+```sh
+export GITHUB_COPILOT_TOKEN_DIR=/path/to/dir   # default ~/.config/litellm/github_copilot
+# the directory must contain a file named `access-token` holding a GitHub OAuth token
+```
+
+litellm does no TTY detection, so a headless run with no cached token prints a
+device code and blocks for roughly three minutes before failing rather than
+erroring immediately.
+
+Copilot currently requires the `process` or `modal` execution backend — the
+`local` backend's generated image-analysis code is tied to an OpenAI client.
+
+### Added: `--embedding_model`, `--embedding_dimensions`, `--dedupe`
+
+Deduplication embeddings were previously hardwired to OpenAI
+`text-embedding-3-large` through a direct OpenAI client. They are now a normal
+model flag, so dedupe can run on any litellm embedding provider:
+
+```sh
+auto-discovery --dedupe \
+    --embedding_model github_copilot/text-embedding-3-small \
+    --embedding_dimensions 1536 \
+    ...
+```
+
+`--dedupe` was previously hardcoded off in the `auto-discovery` entry point and
+is now selectable (`--dedupe` / `--no-dedupe`, default off).
+
+Note that `text-embedding-3-small` at 1536 dimensions is not numerically
+identical to the `text-embedding-3-large` default; keep the default when exact
+embedding geometry matters.
+
+### Added: model flags are validated before the first model call
+
+Every flag is checked at startup against litellm's offline registry: the vision
+model must accept image input, the embedding model must be an embedding model,
+and chat flags must be chat models. A model litellm has not mapped yet is a
+warning, not an error — providers ship models faster than litellm maps them.
+
+For `github_copilot/` the check queries Copilot's own `/models` endpoint
+instead, since litellm's static catalog is inaccurate in both directions for
+Copilot: it lists models an account cannot call and omits ones it can. The live
+list is read from litellm's cached API key and never triggers a login; with no
+usable cached key, validation falls back to the registry with a warning
+([#68]).
+
+### Changed: per-model parameter handling
+
+- `temperature` is dropped, with a warning, for models that reject it. This was
+  a hardcoded `o4-mini` substring check; it now consults litellm's per-model
+  reasoning support.
+- `reasoning_effort=minimal` is mapped to `low` only for OpenAI models that
+  litellm reports cannot take it, instead of for every non-Gemini model.
+- Per-request sample caps (`n`) are applied per provider: 5 for `vertex_ai`, 8
+  for `github_copilot`, 8 for OpenAI reasoning models. Requests above the cap
+  are batched rather than failing.
+- Parameters a model does not support are stripped by litellm
+  (`drop_params`) rather than by hand at each call site.
+
+Retry behavior is unchanged: this package's own truncated exponential backoff
+still applies, configured by `LLM_RETRY_MAX_RETRIES`,
+`LLM_RETRY_INITIAL_DELAY_SECONDS` and `LLM_RETRY_MAX_DELAY_SECONDS`. litellm's
+own `num_retries` is pinned to 0 so there is one retry layer, not two nested
+ones.
+
+### Fixed
+
+- Local dataset paths are resolved to their real file before symlinking into
+  the work directory, and a broken existing symlink no longer silently wins
+  over the resolved source.
+- Directory datasets skip dotfiles at every level, not just the top.
+
+### Packaging
+
+- Added `litellm>=1.97.0,<2` and `google-auth`.
+- Dropped `google-cloud-aiplatform` and the `ag2[openai,gemini]` extras
+  (`ag2==0.10` is still required); provider SDKs are litellm's business now.
+- `LICENSE` is bundled in each published distribution.
+
+---
+
+## Library-level changes
+
+These affect code that imports these packages as a Python library. If you use
+`asta-autodiscovery` only for the `auto-discovery` CLI, nothing below applies.
+
+### Removed modules
+
+- `autodiscovery.vertex_client` and `autodiscovery.vertex_config` — Vertex is
+  reached through litellm, so there is no bespoke OpenAI-compatible client,
+  base-URL builder or credentials refresher.
+- `autodiscovery.log_utils` — dead since it was written.
+- From `autodiscovery.utils`: `is_gemini_model`, `is_reasoning_model`,
+  `normalize_vertex_model_name`, `max_n_for_model`, `normalize_reasoning_effort`,
+  `get_vertex_access_token`, `get_openai_client_for_model`. Their replacements
+  live in the new `autodiscovery.llm` module (`provider_of`, `model_info`,
+  `accepts_temperature`, `max_n`, `normalize_reasoning_effort`, `validate`,
+  `complete`, `embed`).
+- `autodiscovery.agents.get_openai_config` is replaced by
+  `get_llm_config`, and AG2 now talks to models through a `LiteLLMAG2Client`
+  custom client rather than a patched `OpenAIWrapper`.
+
+### Required and keyword-only model arguments
+
+Functions no longer default to a model name, since no default can be
+provider-correct. Model arguments are now required, and several are keyword-only:
+
+- `run.run_mcts(...)` — `model_name`, `belief_model_name`, `vision_model` and
+  `embedding_model` are required keyword arguments.
+- `utils.query_llm(...)` — `model` is required; the `client` parameter is gone.
+- `deduplication.dedupe(...)` — `model` and `embedding_model` are required
+  keyword arguments.
+- `deduplication.get_embedding(...)` — `model` is required; `client` is gone,
+  replaced by an optional `dimensions`.
+- `deduplication.get_llm_merge_decision(...)` — `model` is a required keyword
+  argument.
+- `agents.VisionHandler(vision_model=...)` — required.
+- `run.save_nodes(...)` — takes `embedding_model` and `embedding_dimensions`.
+
+Passing a bare model name to any of these raises
+`autodiscovery.llm.ModelError`.
+
+### `agent_usage_mode="per_response"`
+
+No longer depends on monkey-patching AG2's `OpenAIWrapper`, so it can no longer
+fail at startup with *"the patch could not be applied"*. The custom litellm
+client records each response as it is produced.
+
+[#67]: https://github.com/allenai/asta-autodiscovery/pull/67
+[#68]: https://github.com/allenai/asta-autodiscovery/pull/68
+[#71]: https://github.com/allenai/asta-autodiscovery/pull/71
+
+## 0.2.2 and earlier
+
+Not recorded here. See the
+[commit history](https://github.com/allenai/asta-autodiscovery/commits/main).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 > AutoDiscovery for Asta
 
+## Changelog
+
+Release notes for the published packages, including breaking changes, are in
+[CHANGELOG.md](CHANGELOG.md).
+
 ## Standalone CLI
 
 To run AutoDiscovery against a local dataset without the full Skiff stack, see

--- a/docs/autodiscovery/standalone.md
+++ b/docs/autodiscovery/standalone.md
@@ -177,3 +177,8 @@ Steps:
 
 3. **Trigger the workflow**: in GitHub Actions, run the *Publish to PyPI*
    workflow with the tag (e.g. `v1.1.7`) as the `version` input.
+
+   The workflow publishes the three packages and then creates the matching
+   GitHub release, pointing at the tag's `CHANGELOG.md`. Add the version's
+   changelog entry before releasing — that link is the only per-version notes
+   PyPI consumers get, since PyPI renders only the current long description.

--- a/docs/autodiscovery/standalone.md
+++ b/docs/autodiscovery/standalone.md
@@ -1,17 +1,17 @@
 # Standalone CLI
 
-The `autodiscovery` package ships a console script, `auto-discovery`, that runs the
+The `asta-autodiscovery` package ships a console script, `auto-discovery`, that runs the
 discovery engine end-to-end against a local dataset — no Cloud Run, GCS, or UI
 required.
 
 ## Install from PyPI
 
 ```sh
-pip install autodiscovery
+pip install asta-autodiscovery
 ```
 
-This pulls in `autodiscovery-modal` (sandboxed code execution) as a transitive
-dependency. Requires Python 3.13+.
+This pulls in `asta-autodiscovery-modal` (sandboxed code execution) and
+`asta-code-execution` as transitive dependencies. Requires Python 3.13+.
 
 ## Selecting models
 
@@ -151,7 +151,8 @@ parameters, belief mode, execution backend, etc.).
 ## Publishing to PyPI
 
 Releases are cut from a git tag and published via the
-[`publish-to-pypi`](../.github/workflows/publish-to-pypi.yml) workflow.
+[`publish-to-pypi`](https://github.com/allenai/asta-autodiscovery/blob/main/.github/workflows/publish-to-pypi.yml)
+workflow.
 
 Steps:
 
@@ -161,9 +162,9 @@ Steps:
    make set-version VERSION=x.y.z
    ```
 
-   This keeps all six sub-packages in sync. Only `autodiscovery` and
-   `autodiscovery-modal` are actually published, but we sync the whole workspace
-   so versions don't drift.
+   This keeps all six sub-packages in sync. Only `asta-autodiscovery`,
+   `asta-autodiscovery-modal` and `asta-code-execution` are actually published,
+   but we sync the whole workspace so versions don't drift.
 
 2. Just before merging to main, push the version tag:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Configuration: configuration.md
   - Authentication: authentication.md
   - Autodiscovery:
+      - Standalone CLI: autodiscovery/standalone.md
       - Surprisal Normalization: autodiscovery/surprisal_normalization.md
   - Code Execution:
       - IPython Session: code_execution/ipython_session.md

--- a/packages/agents/pyproject.toml
+++ b/packages/agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-agents"
-version = "0.2.2"
+version = "1.0.0"
 description = "Add your description here"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/autodiscovery/README.md
+++ b/packages/autodiscovery/README.md
@@ -34,10 +34,13 @@ uv run --package autodiscovery python -m autodiscovery.run \
     --out_dir="outputs" \
     --dataset_metadata="discoverybench/real/test/nls_ses/metadata.json" \
     --n_experiments=16 \
-    --model="gemini-3.7-flash" \
-    --belief_model="gemini-3.7-flash" \
-    --vision_model="gemini-3.7-flash"
+    --model="vertex_ai/gemini-3.7-flash" \
+    --belief_model="vertex_ai/gemini-3.7-flash" \
+    --vision_model="vertex_ai/gemini-3.7-flash"
 ```
+
+Model flags take litellm's `<provider>/<model>` naming; the provider prefix is required.
+See [docs/autodiscovery/standalone.md](../../docs/autodiscovery/standalone.md#selecting-models).
 
 To resume a previous exploration, use the `--continue_from_dir` flag to specify the directory containing the previous
 exploration logs. This will allow the script to continue from where it left off, using the MCTS nodes it had generated

--- a/packages/autodiscovery/RELEASE.md
+++ b/packages/autodiscovery/RELEASE.md
@@ -6,6 +6,19 @@ generate follow-up hypotheses in a recursive exploration.
 
 > Link to our NeurIPS 2025 paper: [AutoDiscovery: Open-ended Scientific Discovery via Bayesian Surprise](https://openreview.net/pdf?id=kJqTkj2HhF)
 
+## Upgrading from 0.2.x
+
+1.0.0 changes two things that every existing command line depends on:
+
+- **Model flags now name their provider.** `--model gemini-3.1-pro-preview`
+  becomes `--model vertex_ai/gemini-3.7-flash`. A bare model name is rejected at
+  startup. See [Selecting models](#selecting-models) below.
+- **Vertex AI authenticates via Application Default Credentials only.**
+  `VERTEX_ACCESS_TOKEN`, `GOOGLE_OAUTH_ACCESS_TOKEN` and
+  `VERTEX_OPENAI_BASE_URL` are no longer read.
+
+Full notes: [CHANGELOG](https://github.com/allenai/asta-autodiscovery/blob/main/CHANGELOG.md).
+
 ## Installation
 
 Requires Python 3.13 or newer.

--- a/packages/autodiscovery/pyproject.toml
+++ b/packages/autodiscovery/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-autodiscovery"
-version = "0.2.2"
+version = "1.0.0"
 description = "Open-ended Scientific Discovery via Bayesian Surprise"
 readme = "RELEASE.md"
 license = "Apache-2.0"

--- a/packages/autodiscovery_jobs/pyproject.toml
+++ b/packages/autodiscovery_jobs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-autodiscovery-jobs"
-version = "0.2.2"
+version = "1.0.0"
 description = "Python package for managing Cloud Run jobs with GCS integration"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/__init__.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/__init__.py
@@ -101,7 +101,7 @@ from .user_profile import (
     update_user_profile,
 )
 
-__version__ = "0.2.2"
+__version__ = "1.0.0"
 
 __all__ = [
     # Main class

--- a/packages/autodiscovery_modal/pyproject.toml
+++ b/packages/autodiscovery_modal/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-autodiscovery-modal"
-version = "0.2.2"
+version = "1.0.0"
 description = "Add your description here"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/code_execution/pyproject.toml
+++ b/packages/code_execution/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-code-execution"
-version = "0.2.2"
+version = "1.0.0"
 description = "Add your description here"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/devtools/pyproject.toml
+++ b/packages/devtools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-devtools"
-version = "0.2.2"
+version = "1.0.0"
 description = "Developer tooling for AutoDiscovery"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-autodiscovery-workspace"
-version = "0.2.2"
+version = "1.0.0"
 description = "Asta AutoDiscovery (workspace root)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "asta-agents"
-version = "0.2.2"
+version = "1.0.0"
 source = { editable = "packages/agents" }
 dependencies = [
     { name = "asta-autodiscovery-modal" },
@@ -203,7 +203,7 @@ requires-dist = [
 
 [[package]]
 name = "asta-autodiscovery"
-version = "0.2.2"
+version = "1.0.0"
 source = { editable = "packages/autodiscovery" }
 dependencies = [
     { name = "ag2" },
@@ -246,7 +246,7 @@ requires-dist = [
 
 [[package]]
 name = "asta-autodiscovery-jobs"
-version = "0.2.2"
+version = "1.0.0"
 source = { editable = "packages/autodiscovery_jobs" }
 dependencies = [
     { name = "docker" },
@@ -278,7 +278,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "asta-autodiscovery-modal"
-version = "0.2.2"
+version = "1.0.0"
 source = { editable = "packages/autodiscovery_modal" }
 dependencies = [
     { name = "asta-sandbox", extra = ["modal-ephemeral"] },
@@ -293,7 +293,7 @@ requires-dist = [
 
 [[package]]
 name = "asta-autodiscovery-workspace"
-version = "0.2.2"
+version = "1.0.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]
@@ -337,7 +337,7 @@ dev = [
 
 [[package]]
 name = "asta-code-execution"
-version = "0.2.2"
+version = "1.0.0"
 source = { editable = "packages/code_execution" }
 dependencies = [
     { name = "ipython" },
@@ -348,7 +348,7 @@ requires-dist = [{ name = "ipython", specifier = ">=9.9.0" }]
 
 [[package]]
 name = "asta-devtools"
-version = "0.2.2"
+version = "1.0.0"
 source = { editable = "packages/devtools" }
 dependencies = [
     { name = "google-cloud-storage" },


### PR DESCRIPTION
## Why 1.0.0

The litellm rewrite (#67, #68) breaks every existing `auto-discovery` command line:

1. **Model flags require a `<provider>/<model>` prefix.** `--model gemini-3.1-pro-preview` → `--model vertex_ai/gemini-3.7-flash`. Bare names are rejected at startup.
2. **Vertex AI is ADC-only.** `VERTEX_ACCESS_TOKEN`, `GOOGLE_OAUTH_ACCESS_TOKEN` and `VERTEX_OPENAI_BASE_URL` are no longer read.

Last PyPI release is 0.2.2 (2026-06-15, `3e976267`). Of the 80 commits since, ~24 touch the three published packages, and the substance is #67/#68 plus the Gemini 3.7 Flash default (#71).

## What's here

- **`CHANGELOG.md`** (new). Leads with the two breaking changes and the upgrade path, so it can be handed to anyone running the CLI. Changes that only matter to code importing the packages as a library — removed modules, now-required/keyword-only model arguments — are in a separate section below the fold, since the distribution isn't known to be used as anything but the CLI.
- **`packages/autodiscovery/RELEASE.md`** (the PyPI long description) gets an "Upgrading from 0.2.x" section at the top. That's the page installers land on.
- **Version 1.0.0** across all seven files (`make set-version`).

## Doc fixes

These would have sent a 1.0.0 user to a command that fails at startup:

- `packages/autodiscovery/README.md` still showed bare `--model="gemini-3.7-flash"`.
- `docs/autodiscovery/standalone.md` said `pip install autodiscovery` (wrong package name) and undercounted the published packages.
- **`standalone.md` was never in the mkdocs nav**, so the model-naming instructions weren't on the docs site — the one page most worth pointing people at. Now published under Autodiscovery → Standalone CLI.

## GitHub releases (second commit)

The publish workflow now creates the GitHub release after all three packages publish. PyPI renders only the *current* long description, so a GitHub release is the only place per-version notes live and the only thing watchers can subscribe to. Doing it by hand is the step that gets forgotten: v0.2.1 and v0.2.2 both published to PyPI fine, but neither has a *GitHub* release against its tag, so the Releases tab is empty.

The body links the tag's `CHANGELOG.md` rather than parsing a section out of it, so there's no extraction logic to maintain.

It's a **separate job** so neither token carries the other's authority:

| Job | Permissions | Can reach |
| --- | --- | --- |
| `publish` | `id-token: write`, `contents: read` (unchanged) | PyPI only |
| `release` | `contents: write` | the repo only |

The build steps run third-party code — each package's build backend, plus `pypa/gh-action-pypi-publish@release/v1` on a moving tag rather than a pinned SHA — so that token shouldn't be able to write to the repo, and the release token shouldn't be able to publish. The release job needs no checkout, since `gh` works against the API given `--repo`.

No credential changes required: `permissions:` scopes the per-job `GITHUB_TOKEN`, which GitHub mints and discards automatically. The repo's read-only default (`default_workflow_permissions: read`) stays as it is — an explicit block overrides it, as `deploy-docs.yml` already does for its gh-pages push.

## Verification

- `make test` → 188 passed
- `mkdocs build` → clean (also fixed a pre-existing broken link on the newly-published page)
- `manage-version.py check` → consistent at 1.0.0
- Workflow YAML parses; the release step's rendered shell and notes body were expanded and checked by hand

## Releasing

Unchanged from `standalone.md`: `make push-version-tag` just before merge, then dispatch *Publish to PyPI* with `v1.0.0`. The release is created automatically from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


