### PR TITLE
Stop run_mcts from spinning when no node can be committed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to the published packages — [`asta-autodiscovery`][pypi]
 
 [pypi]: https://pypi.org/project/asta-autodiscovery/
 
+## Unreleased
+
+### Fixed: a run whose experiment generation always fails now stops ([#79])
+
+A durable model failure at the data-loader step — misconfigured Vertex
+project/location, expired credentials, exhausted quota, replies that never parse
+into an experiment — used to spin `run_mcts` at full speed forever, emitting
+gigabytes of the same four log lines and burying the underlying error. It now
+aborts, saves whatever was explored, and raises `run.NoProgressError` naming the
+last failure, so the CLI exits non-zero.
+
+`run.run_mcts(...)` takes a new `max_no_progress_iterations` keyword argument
+(default `3`): the number of consecutive iterations that may commit no node
+before the run aborts.
+
+[#79]: https://github.com/allenai/asta-autodiscovery/issues/79
+
 ## 1.0.0
 
 First release of the litellm-based model layer ([#67], [#68]). Every model call

--- a/packages/autodiscovery/src/autodiscovery/mcts_utils.py
+++ b/packages/autodiscovery/src/autodiscovery/mcts_utils.py
@@ -266,11 +266,14 @@ def select_nodes(selection_method, root, nodes_by_level, n_warmstart=0, return_n
         return_n: Number of nodes to return.
 
     Returns:
-        List of selected MCTSNode instances for expansion.
+        List of selected MCTSNode instances for expansion. Empty when nothing is left to expand.
     """
     # If the data loader node hasn't been executed, return the root. This is not run in batch mode.
+    # Once the root can no longer produce that experiment -- its data-loader experiment was consumed
+    # by an expansion that failed and it is not allowed to generate more -- return nothing, so the
+    # caller stops instead of selecting the root forever.
     if len(nodes_by_level[1]) == 0:
-        return [root]
+        return [root] if root.has_untried_experiments() else []
 
     # If there are warmstart experiments left to run, select the data loader node.
     n_children_at_data_loader = len(nodes_by_level[2])

--- a/packages/autodiscovery/src/autodiscovery/run.py
+++ b/packages/autodiscovery/src/autodiscovery/run.py
@@ -282,6 +282,27 @@ def compute_and_store_reward(
         # TODO: Update all past nodes with the new surprisal set
 
 
+class NoProgressError(RuntimeError):
+    """Raised when exploration stops committing nodes and cannot recover.
+
+    Attributes:
+        iterations: Number of consecutive iterations that committed no node.
+        last_error: The last per-node expansion error, when one was raised.
+    """
+
+    def __init__(self, message, *, iterations, last_error=None):
+        """Initialize the error.
+
+        Args:
+            message: Human-readable description of the stall.
+            iterations: Number of consecutive iterations that committed no node.
+            last_error: The last per-node expansion error, when one was raised.
+        """
+        super().__init__(message)
+        self.iterations = iterations
+        self.last_error = last_error
+
+
 def run_mcts(
     root,
     nodes_by_level,
@@ -324,6 +345,7 @@ def run_mcts(
     batch_size=1,
     n_threads=1,
     agent_usage_mode: str = "per_response",
+    max_no_progress_iterations: int = 3,
 ):
     """Run AutoDS exploration. In MCTS, root node level=0 is a dummy node with no experiment, level=1 is the first real node with the dataset loading experiment, levels > 1 are the actual MCTS nodes with hypotheses and experiments.
 
@@ -371,6 +393,13 @@ def run_mcts(
         agent_usage_mode: Tracking mode for agents chat usage. ``per_response`` records
             usage from each AG2 model response. ``summary_delta`` records usage from
             AG2 usage-summary deltas.
+        max_no_progress_iterations: Number of consecutive iterations that may commit no
+            node before exploration aborts. Guards against a durable failure (bad model
+            credentials, exhausted quota, unparseable replies) spinning the loop forever.
+
+    Raises:
+        NoProgressError: If ``max_no_progress_iterations`` consecutive iterations commit
+            no node. Whatever was explored before the abort is still saved.
     """
 
     def _get_executor_rich_outputs(code_executor_agent) -> list:
@@ -405,6 +434,8 @@ def run_mcts(
 
     usage_tracker = UsageTracker()
     usage_tracker.save_events(log_dirname)
+
+    no_progress_error: NoProgressError | None = None
 
     try:
         if agent_usage_mode == "per_response":
@@ -474,8 +505,34 @@ def run_mcts(
         total_to_sample = max_iterations
         n_sampled = 0
         iteration_idx = 0
+        consecutive_no_progress = 0
+        last_expansion_error: Exception | None = None
+        expansion_error_guard = threading.Lock()
         node_mutation_locks: dict[str, threading.Lock] = {}
         node_mutation_locks_guard = threading.Lock()
+
+        def _on_expand_error(node_id: str, exc: Exception) -> None:
+            """Report a failed node expansion and remember it as the latest failure cause."""
+            nonlocal last_expansion_error
+            with expansion_error_guard:
+                last_expansion_error = exc
+            # Keep exploration running when one node expansion fails.
+            print(f"[run_mcts] Failed expanding node {node_id}: {exc.__class__.__name__}: {exc}")
+            traceback.print_exception(type(exc), exc, exc.__traceback__)
+
+        def _no_progress_error(reason: str) -> NoProgressError:
+            """Build the abort error for a stalled run, naming the last underlying failure."""
+            cause = (
+                f"{last_expansion_error.__class__.__name__}: {last_expansion_error}"
+                if last_expansion_error is not None
+                else "no usable experiment was generated"
+            )
+            return NoProgressError(
+                f"Exploration aborted: {reason} "
+                f"({n_sampled}/{total_to_sample} experiments completed). Last failure: {cause}",
+                iterations=consecutive_no_progress,
+                last_error=last_expansion_error,
+            )
 
         def _get_node_mutation_lock(node_obj: MCTSNode) -> threading.Lock:
             """Return a per-node lock used to serialize mutable node state updates."""
@@ -501,6 +558,14 @@ def run_mcts(
                 return_n=min(batch_size, remaining_budget),
             )[:remaining_budget]
             if not next_nodes:
+                # Running out of nodes is the normal way exploration ends early. It is a failure
+                # only when the tree ran dry because expansion kept erroring, or when the run never
+                # committed a single node (e.g. the data loader could never be created).
+                if consecutive_no_progress and (last_expansion_error is not None or n_sampled == 0):
+                    raise _no_progress_error(
+                        f"no node is left to expand after {consecutive_no_progress} "
+                        "consecutive iteration(s) that committed no node"
+                    ) from last_expansion_error
                 break
             print(
                 "SAMPLED "
@@ -772,14 +837,6 @@ def run_mcts(
                         is_threaded=True,
                     )
 
-                def _on_expand_error(node_id: str, exc: Exception) -> None:
-                    # Keep exploration running when one node expansion fails.
-                    print(
-                        f"[run_mcts] Failed expanding node {node_id}: "
-                        f"{exc.__class__.__name__}: {exc}"
-                    )
-                    traceback.print_exception(type(exc), exc, exc.__traceback__)
-
                 expanded_nodes = []
                 with ThreadPoolExecutor(max_workers=n_threads) as executor:
                     future_labels = {
@@ -834,11 +891,7 @@ def run_mcts(
                         )
                     except Exception as exc:
                         # Align sequential behavior with threaded mode by continuing after per-node failures.
-                        print(
-                            f"[run_mcts] Failed expanding node {node_id}: "
-                            f"{exc.__class__.__name__}: {exc}"
-                        )
-                        traceback.print_exception(type(exc), exc, exc.__traceback__)
+                        _on_expand_error(node_id, exc)
                         continue
                     if new_node is not None:
                         expanded_nodes.append(new_node)
@@ -850,8 +903,29 @@ def run_mcts(
             expanded_nodes.sort(key=lambda n: (n.level, n.node_idx))
             for node in expanded_nodes:
                 nodes_by_level[node.level].append(node)
+
+            # Abort instead of spinning when nothing gets committed iteration after iteration.
+            # Without this, a durable failure (bad credentials, exhausted quota, replies that never
+            # parse into an experiment) loops at full speed and buries its own cause in log noise.
+            if expanded_nodes:
+                consecutive_no_progress = 0
+                last_expansion_error = None
+            else:
+                consecutive_no_progress += 1
+                print(
+                    f"NO NODE COMMITTED IN ITERATION {iteration_idx} "
+                    f"({consecutive_no_progress}/{max_no_progress_iterations} consecutive)\n"
+                )
+                if consecutive_no_progress >= max_no_progress_iterations:
+                    raise _no_progress_error(
+                        f"{consecutive_no_progress} consecutive iterations committed no node"
+                    ) from last_expansion_error
     except KeyboardInterrupt:
         print("\n\n######### EXPLORATION INTERRUPTED! SAVING THE CURRENT STATE... #########\n\n")
+    except NoProgressError as exc:
+        # Save whatever was explored before re-raising, so the partial run is not lost.
+        no_progress_error = exc
+        print(f"\n\n######### EXPLORATION ABORTED! {exc} #########\n\n")
     finally:
         clear_ag2_usage_context()
         configure_ag2_usage_tracking(None)
@@ -873,6 +947,10 @@ def run_mcts(
     )
     usage_tracker.save_events(log_dirname)
     usage_tracker.save_summary(log_dirname)
+
+    if no_progress_error is not None:
+        # Surface the failure to the caller (non-zero exit for the CLI) now that state is saved.
+        raise no_progress_error
 
 
 def resolve_model_args(args) -> None:

--- a/packages/autodiscovery/tests/test_run_no_progress.py
+++ b/packages/autodiscovery/tests/test_run_no_progress.py
@@ -1,0 +1,205 @@
+"""Exploration must stop -- not spin -- when node expansion keeps failing."""
+
+import json
+from collections import defaultdict
+
+import pytest
+from autodiscovery import run as run_module
+from autodiscovery.mcts import MCTSNode
+from autodiscovery.mcts_utils import select_nodes
+from autodiscovery.run import NoProgressError, run_mcts
+
+LOAD_DATASET_EXPERIMENT = {
+    "hypothesis": None,
+    "experiment_plan": {
+        "objective": "Load the dataset.",
+        "steps": "1. Load data.csv",
+        "deliverables": "1. Dataset loaded.",
+    },
+}
+
+
+class _AlwaysGeneratesExperiments:
+    """Experiment generator that always returns one valid experiment."""
+
+    def generate_reply(self, messages=None, **kwargs):
+        return (
+            '{"experiments": [{"hypothesis": "h", "experiment_plan": '
+            '{"objective": "o", "steps": "s", "deliverables": "d"}}]}'
+        )
+
+
+class _NeverGeneratesExperiments:
+    """Experiment generator whose replies never parse into an experiment."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def generate_reply(self, messages=None, **kwargs):
+        self.calls += 1
+        return "Vertex AI project not set."
+
+
+class _UserProxy:
+    """Stand-in for the user proxy agent; the chat itself is not under test."""
+
+    def initiate_chat(self, recipient=None, message=None, clear_history=False):
+        return None
+
+
+class _FakeGroupChat:
+    def __init__(self):
+        self.messages = [
+            {
+                "name": "user_proxy",
+                "role": "user",
+                "content": (
+                    "Hypothesis: h\n\nExperiment objective: o\n\n"
+                    "Steps for the programmer:\ns\n\nDeliverables:\nd"
+                ),
+            }
+        ]
+
+
+class _FakeChatManager:
+    def resume(self, messages=None):
+        return None, "last message"
+
+    def messages_to_string(self, messages):
+        return json.dumps(messages)
+
+
+def _succeeding_group_chat(agents, max_rounds):
+    """Group chat stub whose node expansion always completes, committing the node."""
+    return _FakeGroupChat(), _FakeChatManager()
+
+
+def _make_root(untried_experiments=None, allow_generate_experiments=False):
+    root = MCTSNode(
+        level=0,
+        node_idx=0,
+        hypothesis=None,
+        query=None,
+        allow_generate_experiments=allow_generate_experiments,
+        untried_experiments=untried_experiments,
+    )
+    nodes_by_level = defaultdict(list)
+    nodes_by_level[0].append(root)
+    return root, nodes_by_level
+
+
+def _install_stubs(monkeypatch, experiment_generator, on_group_chat):
+    """Replace the agent/chat/persistence layers so no model or filesystem work happens."""
+    agent_objs = {
+        "experiment_generator": experiment_generator,
+        "user_proxy": _UserProxy(),
+        "code_executor": object(),
+    }
+    monkeypatch.setattr(run_module, "get_agents", lambda *args, **kwargs: agent_objs)
+    monkeypatch.setattr(run_module, "setup_group_chat", on_group_chat)
+    monkeypatch.setattr(run_module, "save_nodes", lambda *args, **kwargs: None)
+
+
+def _run(root, nodes_by_level, tmp_path, **kwargs):
+    return run_mcts(
+        root=root,
+        nodes_by_level=nodes_by_level,
+        dataset_paths=[],
+        log_dirname=str(tmp_path / "logs"),
+        work_dir=str(tmp_path / "work"),
+        model_name="openai/gpt-4o",
+        belief_model_name="openai/gpt-4o",
+        vision_model="openai/gpt-4o",
+        embedding_model="openai/text-embedding-3-small",
+        max_iterations=50,
+        **kwargs,
+    )
+
+
+def test_run_mcts_aborts_when_data_loader_node_cannot_be_created(tmp_path, monkeypatch, capsys):
+    """A durable failure at the data-loader step ends the run instead of looping forever."""
+    root, nodes_by_level = _make_root(untried_experiments=[LOAD_DATASET_EXPERIMENT])
+
+    def _fail(*args, **kwargs):
+        raise RuntimeError("Vertex AI project not set")
+
+    _install_stubs(monkeypatch, _AlwaysGeneratesExperiments(), _fail)
+
+    with pytest.raises(NoProgressError) as excinfo:
+        _run(root, nodes_by_level, tmp_path)
+
+    # The underlying cause is surfaced, not buried under repeated selection noise.
+    assert "Vertex AI project not set" in str(excinfo.value)
+    assert isinstance(excinfo.value.last_error, RuntimeError)
+    assert nodes_by_level[1] == []
+
+    # Log output is bounded: the loop cannot have run more iterations than the guard allows.
+    output = capsys.readouterr().out
+    assert output.count("######### ITERATION") <= 3
+
+
+def test_run_mcts_aborts_when_experiment_generation_always_fails(tmp_path, monkeypatch, capsys):
+    """Replies that never parse into an experiment stop the run after a bounded number of tries."""
+    root, nodes_by_level = _make_root(allow_generate_experiments=True)
+    generator = _NeverGeneratesExperiments()
+
+    def _unreachable(*args, **kwargs):  # pragma: no cover - no node ever gets that far
+        raise AssertionError("no node should be expanded")
+
+    _install_stubs(monkeypatch, generator, _unreachable)
+
+    with pytest.raises(NoProgressError):
+        _run(root, nodes_by_level, tmp_path)
+
+    output = capsys.readouterr().out
+    assert output.count("######### ITERATION") <= 3
+    assert output.count("No new experiment generated") <= 3
+
+
+def test_run_mcts_aborts_after_max_no_progress_iterations(tmp_path, monkeypatch, capsys):
+    """A node that keeps generating experiments but never commits one stops at the threshold."""
+    root, nodes_by_level = _make_root(
+        untried_experiments=[LOAD_DATASET_EXPERIMENT], allow_generate_experiments=True
+    )
+
+    def _fail(*args, **kwargs):
+        raise RuntimeError("quota exhausted")
+
+    _install_stubs(monkeypatch, _AlwaysGeneratesExperiments(), _fail)
+
+    with pytest.raises(NoProgressError) as excinfo:
+        _run(root, nodes_by_level, tmp_path, max_no_progress_iterations=2)
+
+    assert excinfo.value.iterations == 2
+    assert "quota exhausted" in str(excinfo.value)
+    assert capsys.readouterr().out.count("######### ITERATION") == 2
+
+
+def test_run_mcts_exits_cleanly_when_the_tree_is_exhausted(tmp_path, monkeypatch):
+    """Running out of nodes after committing work is a normal ending, not a failure."""
+    root, nodes_by_level = _make_root(
+        untried_experiments=[LOAD_DATASET_EXPERIMENT], allow_generate_experiments=True
+    )
+    generator = _NeverGeneratesExperiments()
+
+    _install_stubs(monkeypatch, generator, _succeeding_group_chat)
+
+    # First iteration commits the data-loader node; then generation dries up and selection
+    # runs out of nodes. That must return normally, keeping the committed node.
+    _run(root, nodes_by_level, tmp_path)
+
+    assert len(nodes_by_level[1]) == 1
+    assert generator.calls > 0
+
+
+def test_select_nodes_returns_nothing_when_root_is_exhausted():
+    """The root is no longer selected once it can neither retry nor generate an experiment."""
+    root, nodes_by_level = _make_root(untried_experiments=[LOAD_DATASET_EXPERIMENT])
+
+    assert select_nodes(None, root, nodes_by_level) == [root]
+
+    # Simulate the data-loader experiment being consumed by an expansion that failed.
+    root.untried_experiments = []
+    root.allow_generate_experiments = False
+
+    assert select_nodes(None, root, nodes_by_level) == []


### PR DESCRIPTION
Fixes #79.

A durable model failure at the data-loader step used to spin `run_mcts` forever
(3.9 GB of log in 90 s, three of those lines the actual error). Two independent
guards, as the issue prescribes:

1. **Bound no-progress iterations in `run_mcts`.** Consecutive iterations that
   commit no node are counted; past `max_no_progress_iterations` (new keyword
   argument, default 3) the run aborts with a new `run.NoProgressError` naming
   the last underlying failure. Whatever was explored is saved first, then the
   error propagates, so the CLI exits non-zero. Running out of selectable nodes
   is still a normal ending — it is only treated as a failure when expansion was
   erroring or when the run never committed a single node.
2. **Stop returning `[root]` unconditionally.** `select_nodes` returns `[]` once
   the root has no untried experiments and cannot generate more, so the existing
   `if not next_nodes: break` escape becomes reachable.

The duplicated per-node failure reporting in the sequential and threaded
expansion paths is folded into one helper, which is also where the last error is
recorded.

### Acceptance

- [x] A run whose experiment generation always fails terminates with a non-zero
      exit and surfaces the underlying error.
- [x] Log output for that run is bounded (at most `max_no_progress_iterations`
      iterations of the repeated lines).
- [x] Regression tests in `packages/autodiscovery/tests/test_run_no_progress.py`
      drive `run_mcts` with an always-failing generator and assert termination,
      the surfaced cause, and the bounded iteration count. A fifth test pins the
      benign case: a tree that runs dry after committing work still exits
      cleanly.

### Verification

Against the pre-fix code, a script reproducing the issue (data-loader expansion
always raising) had to be killed at a 15 s timeout. With the fix it terminates
immediately:

```
TERMINATED: NoProgressError: Exploration aborted: no node is left to expand
after 1 consecutive iteration(s) that committed no node (0/50 experiments
completed). Last failure: RuntimeError: Vertex AI project not set
```

`uv run --all-packages pytest -m "not modal and not adc"` — 192 passed, 1 failed.
The failure is `packages/code_execution/tests/test_ipython_session.py::test_run_cell_subprocess_success`,
which also fails on a clean checkout of `main` in this sandbox (subprocess
IPython), unrelated to this change.

Co-authored-by: @dirkraft
