### PR TITLE
Replace the hand-maintained LLM price table with litellm's cost data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ All notable changes to the published packages — [`asta-autodiscovery`][pypi]
 
 [pypi]: https://pypi.org/project/asta-autodiscovery/
 
+## Unreleased
+
+### Runs record what each model call cost ([#70])
+
+A run's `llm_usage_summary.json` and `llm_usage_events.jsonl` now carry the cost
+litellm computed for each call, alongside the token counts. Every usage bucket
+gains `cost_usd`, `prompt_cost_usd`, `completion_cost_usd`, `reasoning_cost_usd`
+and `calls_with_cost`; each event gains a `cost` object.
+
+Cost is reported as **unavailable** — not as zero — where it is genuinely not
+known. litellm prices every `github_copilot` model at zero because Copilot bills
+"premium requests" rather than tokens, so no honest per-token figure exists for
+it, and models litellm has not mapped yet have no price at all.
+`calls_with_cost` is what tells an unpriced call apart from a free one.
+
+This replaces the metrics dashboard's hand-maintained price table, which billed
+any unlisted model at Gemini 3.1 Pro's rate and priced `github_copilot/gpt-4o`
+as OpenAI's `gpt-4o`. Runs that completed before this change carry no cost field
+and the dashboard reports their cost as unavailable; their previous figures were
+approximations from that table, and a gap is better than silently mixing two
+costing methods in one dashboard.
+
+[#70]: https://github.com/allenai/asta-autodiscovery/issues/70
+
 ## 1.0.0
 
 First release of the litellm-based model layer ([#67], [#68]). Every model call

--- a/api/metrics/aggregator.py
+++ b/api/metrics/aggregator.py
@@ -26,7 +26,16 @@ from typing import Any
 from autodiscovery_jobs.config import JobConfig
 from google.cloud import storage
 
-from .costs import _lookup_pricing, calculate_llm_cost, get_duration_seconds
+from .costs import (
+    UNAVAILABLE,
+    bucket_call_counts,
+    bucket_costs,
+    calculate_llm_cost,
+    coerce_float,
+    coerce_int,
+    cost_status,
+    get_duration_seconds,
+)
 from .models import (
     AggregatedUsageBucket,
     AggregatedUsageResponse,
@@ -73,6 +82,7 @@ class JobSnapshot:
     model: str | None = None
     llm_usage_summary: dict | None = None
     llm_cost_usd: float = 0.0
+    llm_cost_status: str = UNAVAILABLE
     llm_cost_by_agent: dict[str, dict[str, float]] = field(default_factory=dict)
     llm_cost_by_component: dict[str, dict[str, float]] = field(default_factory=dict)
     llm_cost_by_node: dict[str, dict[str, float]] = field(default_factory=dict)
@@ -178,46 +188,14 @@ def _load_persisted_cache(bucket: storage.Bucket) -> AggregatedData | None:
     )
 
 
-def _coerce_nonnegative_int(value: object) -> int:
-    """Parse a value into a non-negative int, returning 0 on invalid input."""
-    try:
-        return max(0, int(value))  # type: ignore[arg-type]
-    except (TypeError, ValueError):
-        return 0
-
-
-def _lookup_bucket_cost_by_type(model_name: str, bucket: dict[str, Any]) -> tuple[float, float, float]:
-    """Calculate prompt/completion/reasoning costs for one usage bucket."""
-    pricing = _lookup_pricing(model_name)
-
-    prompt_tokens = _coerce_nonnegative_int(bucket.get("prompt_tokens"))
-    completion_tokens = _coerce_nonnegative_int(bucket.get("completion_tokens"))
-    reasoning_tokens = _coerce_nonnegative_int(bucket.get("reasoning_tokens"))
-    total_tokens = _coerce_nonnegative_int(bucket.get("total_tokens"))
-
-    output_tokens = max(0, total_tokens - prompt_tokens)
-    prompt_cost = (prompt_tokens / 1_000_000) * pricing["input"]
-    output_cost = (output_tokens / 1_000_000) * pricing["output"]
-
-    explicit_output_tokens = completion_tokens + reasoning_tokens
-    if explicit_output_tokens > 0:
-        completion_cost = output_cost * (completion_tokens / explicit_output_tokens)
-        reasoning_cost = output_cost * (reasoning_tokens / explicit_output_tokens)
-    else:
-        completion_cost = output_cost
-        reasoning_cost = 0.0
-
-    return prompt_cost, completion_cost, reasoning_cost
-
-
 def _extract_event_bucket(event: dict[str, Any]) -> dict[str, int]:
     """Extract normalized token counts from one usage event."""
     usage = event.get("usage") if isinstance(event.get("usage"), dict) else {}
     usage = usage if isinstance(usage, dict) else {}
 
-    prompt_tokens = _coerce_nonnegative_int(usage.get("prompt_tokens"))
-    completion_tokens = _coerce_nonnegative_int(usage.get("completion_tokens"))
-    total_tokens = _coerce_nonnegative_int(usage.get("total_tokens"))
+    prompt_tokens = coerce_int(usage.get("prompt_tokens"))
+    completion_tokens = coerce_int(usage.get("completion_tokens"))
+    total_tokens = coerce_int(usage.get("total_tokens"))
     if total_tokens == 0:
         total_tokens = prompt_tokens + completion_tokens
 
@@ -227,9 +205,9 @@ def _extract_event_bucket(event: dict[str, Any]) -> dict[str, int]:
         else {}
     )
     completion_details = completion_details if isinstance(completion_details, dict) else {}
-    reasoning_tokens = _coerce_nonnegative_int(completion_details.get("reasoning_tokens"))
+    reasoning_tokens = coerce_int(completion_details.get("reasoning_tokens"))
     if reasoning_tokens == 0:
-        reasoning_tokens = _coerce_nonnegative_int(usage.get("reasoning_tokens"))
+        reasoning_tokens = coerce_int(usage.get("reasoning_tokens"))
 
     return {
         "prompt_tokens": prompt_tokens,
@@ -246,22 +224,37 @@ def _empty_cost_bucket() -> dict[str, float]:
         "completion_cost_usd": 0.0,
         "reasoning_cost_usd": 0.0,
         "total_cost_usd": 0.0,
+        "calls": 0.0,
+        "priced_calls": 0.0,
+    }
+
+
+def _event_cost(event: dict[str, Any]) -> dict[str, float] | None:
+    """Read the cost the producing run recorded for one usage event."""
+    cost = event.get("cost")
+    if not isinstance(cost, dict) or cost.get("total_usd") is None:
+        return None
+    return {
+        "total_cost_usd": coerce_float(cost.get("total_usd")),
+        "prompt_cost_usd": coerce_float(cost.get("prompt_usd")),
+        "completion_cost_usd": coerce_float(cost.get("completion_usd")),
+        "reasoning_cost_usd": coerce_float(cost.get("reasoning_usd")),
     }
 
 
 def _accumulate_cost(
     target: dict[str, dict[str, float]],
     key: str,
-    prompt_cost: float,
-    completion_cost: float,
-    reasoning_cost: float,
+    cost: dict[str, float] | None,
 ) -> None:
-    """Accumulate one usage event cost into a keyed cost map."""
+    """Accumulate one usage event's recorded cost into a keyed cost map."""
     bucket = target.setdefault(key, _empty_cost_bucket())
-    bucket["prompt_cost_usd"] += prompt_cost
-    bucket["completion_cost_usd"] += completion_cost
-    bucket["reasoning_cost_usd"] += reasoning_cost
-    bucket["total_cost_usd"] += prompt_cost + completion_cost + reasoning_cost
+    bucket["calls"] += 1
+    if cost is None:
+        return
+    bucket["priced_calls"] += 1
+    for cost_key, value in cost.items():
+        bucket[cost_key] += value
 
 
 def _build_event_cost_breakdowns(
@@ -271,23 +264,16 @@ def _build_event_cost_breakdowns(
     dict[str, dict[str, float]],
     dict[str, dict[str, float]],
 ]:
-    """Build exact cost maps from raw usage events by agent/component/node."""
+    """Build cost maps from raw usage events by agent/component/node."""
     by_agent: dict[str, dict[str, float]] = {}
     by_component: dict[str, dict[str, float]] = {}
     by_node: dict[str, dict[str, float]] = {}
 
     for event in events:
-        model = str(event.get("model") or "unknown")
-        bucket = _extract_event_bucket(event)
-        prompt_cost, completion_cost, reasoning_cost = _lookup_bucket_cost_by_type(model, bucket)
-
-        agent_key = str(event.get("agent_name") or "unassigned")
-        component_key = str(event.get("component") or "unknown")
-        node_key = str(event.get("node_id") or "run_level")
-
-        _accumulate_cost(by_agent, agent_key, prompt_cost, completion_cost, reasoning_cost)
-        _accumulate_cost(by_component, component_key, prompt_cost, completion_cost, reasoning_cost)
-        _accumulate_cost(by_node, node_key, prompt_cost, completion_cost, reasoning_cost)
+        cost = _event_cost(event)
+        _accumulate_cost(by_agent, str(event.get("agent_name") or "unassigned"), cost)
+        _accumulate_cost(by_component, str(event.get("component") or "unknown"), cost)
+        _accumulate_cost(by_node, str(event.get("node_id") or "run_level"), cost)
 
     return by_agent, by_component, by_node
 
@@ -304,10 +290,10 @@ def _derive_requested_experiments(
     metadata = metadata or {}
     run_args = run_args or {}
 
-    requested_main = _coerce_nonnegative_int(
+    requested_main = coerce_int(
         metadata.get("n_experiments") or run_args.get("n_experiments"),
     )
-    requested_warmstart = _coerce_nonnegative_int(
+    requested_warmstart = coerce_int(
         metadata.get("n_warmstart") or run_args.get("n_warmstart"),
     )
     return requested_main + requested_warmstart
@@ -416,6 +402,7 @@ def _scan_job(
             model=model,
             llm_usage_summary=llm_summary,
             llm_cost_usd=llm_cost,
+            llm_cost_status=cost_status(llm_summary),
             llm_cost_by_agent=llm_cost_by_agent,
             llm_cost_by_component=llm_cost_by_component,
             llm_cost_by_node=llm_cost_by_node,
@@ -465,8 +452,8 @@ def _scan_all_jobs(
                 ):
                     continue
                 # Force one-time re-scan when older cached snapshots predate
-                # exact event-level cost attribution fields.
-                if not hasattr(j, "llm_cost_by_agent"):
+                # event-level cost attribution fields.
+                if not hasattr(j, "llm_cost_by_agent") or not hasattr(j, "llm_cost_status"):
                     continue
                 cached_terminal[(j.userid, j.jobid)] = j
 
@@ -702,6 +689,11 @@ def get_metrics_cache() -> MetricsCache:
 # Query helpers
 # ---------------------------------------------------------------------------
 
+def _count_runs_missing_cost(jobs: list[JobSnapshot]) -> int:
+    """Count runs contributing no cost, so a total can be caveated not inflated."""
+    return sum(1 for j in jobs if j.llm_cost_status == UNAVAILABLE)
+
+
 def _filter_jobs(
     jobs: list[JobSnapshot],
     start_date: str | None = None,
@@ -757,13 +749,17 @@ def compute_overview(
         else 0.0
     )
 
-    # LLM costs
+    # LLM costs. Runs with no recorded cost contribute nothing and are counted
+    # separately so the dashboard can caveat the total rather than imply it is
+    # complete — see api/metrics/costs.py.
     total_llm = sum(j.llm_cost_usd for j in jobs)
+    runs_missing_cost = _count_runs_missing_cost(jobs)
 
-    # Cost per hypothesis — only consider jobs with LLM usage data
-    jobs_with_usage = [j for j in jobs if j.llm_usage_summary]
-    hypotheses_with_usage = sum(j.n_experiments_completed for j in jobs_with_usage)
-    llm_cost_for_hypotheses = sum(j.llm_cost_usd for j in jobs_with_usage)
+    # Cost per hypothesis — only consider jobs whose cost is known, so the
+    # denominator matches the numerator.
+    jobs_with_cost = [j for j in jobs if j.llm_cost_status != UNAVAILABLE]
+    hypotheses_with_usage = sum(j.n_experiments_completed for j in jobs_with_cost)
+    llm_cost_for_hypotheses = sum(j.llm_cost_usd for j in jobs_with_cost)
     cost_per_hypothesis = (
         llm_cost_for_hypotheses / hypotheses_with_usage
         if hypotheses_with_usage > 0
@@ -817,6 +813,7 @@ def compute_overview(
         total_experiments_requested=total_experiments_requested,
         experiment_completion_rate=round(exp_completion_rate, 4),
         llm_cost_usd=round(total_llm, 4),
+        runs_missing_cost=runs_missing_cost,
         hypotheses_with_usage=hypotheses_with_usage,
         cost_per_hypothesis_usd=round(cost_per_hypothesis, 4) if cost_per_hypothesis is not None else None,
         share_rate=round(share_rate, 4),
@@ -865,6 +862,7 @@ def compute_users_list(
                 success_rate=round(sr, 4),
                 total_experiments=total_experiments,
                 llm_cost_usd=round(total_llm, 4),
+                runs_missing_cost=_count_runs_missing_cost(user_jobs),
                 shared_runs=shared,
                 last_activity=last_activity,
             )
@@ -902,6 +900,7 @@ def compute_user_detail(userid: str) -> UserDetailMetrics:
         success_rate=round(sr, 4),
         total_experiments=total_experiments,
         llm_cost_usd=round(total_llm, 4),
+        runs_missing_cost=_count_runs_missing_cost(user_jobs),
         shared_runs=shared,
         last_activity=last_activity,
     )
@@ -924,6 +923,7 @@ def compute_user_detail(userid: str) -> UserDetailMetrics:
                 is_shared=j.is_shared,
                 model=j.model,
                 llm_cost_usd=j.llm_cost_usd,
+                llm_cost_status=j.llm_cost_status,
             )
         )
 
@@ -962,6 +962,7 @@ def compute_run_metrics(userid: str, runid: str) -> dict | None:
         "duration_seconds": job.duration_seconds,
         "llm_usage_summary": job.llm_usage_summary,
         "llm_cost_usd": job.llm_cost_usd,
+        "llm_cost_status": job.llm_cost_status,
         "llm_cost_by_model": llm_cost_by_model,
         "n_experiments_requested": job.n_experiments_requested,
         "n_experiments_completed": job.n_experiments_completed,
@@ -974,6 +975,7 @@ def _build_aggregated_bucket(
     per_run_tokens: list[int],
     per_run_costs: list[float],
     total_calls: int,
+    priced_calls: int,
     total_prompt: int,
     total_completion: int,
     total_reasoning: int,
@@ -992,6 +994,7 @@ def _build_aggregated_bucket(
 
     return AggregatedUsageBucket(
         total_calls=total_calls,
+        priced_calls=priced_calls,
         total_prompt_tokens=total_prompt,
         total_completion_tokens=total_completion,
         total_reasoning_tokens=total_reasoning,
@@ -1022,27 +1025,16 @@ def compute_aggregated_usage(
         return AggregatedUsageResponse()
 
     def _extract_run_costs_by_type(llm_summary: dict | None) -> tuple[float, float, float]:
-        """Compute per-run prompt/completion/reasoning costs from by_model usage."""
-        if not llm_summary:
-            return 0.0, 0.0, 0.0
-
-        by_model = llm_summary.get("by_model", {})
-        prompt_cost = 0.0
-        completion_cost = 0.0
-        reasoning_cost = 0.0
-
-        for model_name, bucket in by_model.items():
-            p_cost, c_cost, r_cost = _lookup_bucket_cost_by_type(model_name, bucket)
-            prompt_cost += p_cost
-            completion_cost += c_cost
-            reasoning_cost += r_cost
-
-        return prompt_cost, completion_cost, reasoning_cost
+        """Sum a run's recorded prompt/completion/reasoning costs across models."""
+        by_model = llm_summary.get("by_model", {}) if llm_summary else {}
+        parts = [bucket_costs(bucket) for bucket in by_model.values()]
+        return tuple(sum(v) for v in zip(*parts, strict=True)) if parts else (0.0, 0.0, 0.0)
 
     # --- Totals ---
     totals_per_run_tokens: list[int] = []
     totals_per_run_costs: list[float] = []
     totals_calls = 0
+    totals_priced_calls = 0
     totals_prompt = 0
     totals_completion = 0
     totals_reasoning = 0
@@ -1054,7 +1046,9 @@ def compute_aggregated_usage(
 
     for j in jobs_with_usage:
         t = j.llm_usage_summary.get("totals", {})  # type: ignore[union-attr]
-        totals_calls += t.get("calls", 0)
+        run_calls, run_priced_calls = bucket_call_counts(t)
+        totals_calls += run_calls
+        totals_priced_calls += run_priced_calls
         totals_prompt += t.get("prompt_tokens", 0)
         totals_completion += t.get("completion_tokens", 0)
         totals_reasoning += t.get("reasoning_tokens", 0)
@@ -1063,7 +1057,9 @@ def compute_aggregated_usage(
         run_prompt_cost, run_completion_cost, run_reasoning_cost = _extract_run_costs_by_type(
             j.llm_usage_summary,
         )
-        run_total_cost = run_prompt_cost + run_completion_cost + run_reasoning_cost
+        # Not the sum of the three parts: calls recorded from AG2's running
+        # per-agent totals know their total cost but not its split.
+        run_total_cost, _ = calculate_llm_cost(j.llm_usage_summary or {})
 
         totals_cost += run_total_cost
         totals_prompt_cost += run_prompt_cost
@@ -1074,7 +1070,7 @@ def compute_aggregated_usage(
 
     totals_bucket = _build_aggregated_bucket(
         totals_per_run_tokens, totals_per_run_costs,
-        totals_calls, totals_prompt, totals_completion,
+        totals_calls, totals_priced_calls, totals_prompt, totals_completion,
         totals_reasoning, totals_tokens, totals_cost,
         totals_prompt_cost, totals_completion_cost, totals_reasoning_cost,
     )
@@ -1082,11 +1078,21 @@ def compute_aggregated_usage(
     # --- Breakdown dimensions ---
     def _aggregate_dimension(
         dim_key: str,
-        cost_mode: str = "none",
+        cost_source: str,
     ) -> dict[str, AggregatedUsageBucket]:
+        """Aggregate one breakdown dimension across runs.
+
+        Args:
+            dim_key: The ``llm_usage_summary`` key to aggregate, e.g. ``by_model``.
+            cost_source: ``summary`` to read cost off the summary buckets, or
+                ``events`` to read the per-event attribution maps.
+
+        Returns:
+            Mapping of dimension key to its aggregated bucket.
+        """
         # Accumulate per-key data across runs
         key_data: dict[str, dict] = defaultdict(lambda: {
-            "calls": 0, "prompt": 0, "completion": 0, "reasoning": 0,
+            "calls": 0, "priced_calls": 0, "prompt": 0, "completion": 0, "reasoning": 0,
             "tokens": 0,
             "cost": 0.0,
             "prompt_cost": 0.0,
@@ -1100,54 +1106,40 @@ def compute_aggregated_usage(
             dim = j.llm_usage_summary.get(dim_key, {})  # type: ignore[union-attr]
             for key, bucket in dim.items():
                 d = key_data[key]
-                prompt_tokens = max(0, int(bucket.get("prompt_tokens", 0) or 0))
-                completion_tokens = max(0, int(bucket.get("completion_tokens", 0) or 0))
-                reasoning_tokens = max(0, int(bucket.get("reasoning_tokens", 0) or 0))
-                tok = max(0, int(bucket.get("total_tokens", 0) or 0))
-                d["calls"] += bucket.get("calls", 0)
-                d["prompt"] += prompt_tokens
-                d["completion"] += completion_tokens
-                d["reasoning"] += reasoning_tokens
+                tok = coerce_int(bucket.get("total_tokens"))
+                calls, priced_calls = bucket_call_counts(bucket)
+                d["calls"] += calls
+                d["prompt"] += coerce_int(bucket.get("prompt_tokens"))
+                d["completion"] += coerce_int(bucket.get("completion_tokens"))
+                d["reasoning"] += coerce_int(bucket.get("reasoning_tokens"))
                 d["tokens"] += tok
                 d["per_run_tokens"].append(tok)
 
-                prompt_cost = 0.0
-                completion_cost = 0.0
-                reasoning_cost = 0.0
-                if cost_mode == "model":
-                    prompt_cost, completion_cost, reasoning_cost = _lookup_bucket_cost_by_type(
-                        key,
-                        bucket,
+                if cost_source == "summary":
+                    total_cost = coerce_float(bucket.get("cost_usd"))
+                    prompt_cost, completion_cost, reasoning_cost = bucket_costs(bucket)
+                else:
+                    # The event-level maps attribute cost to the dimension the
+                    # summary buckets cannot: an agent, component or node.
+                    cost_bucket = getattr(j, f"llm_cost_{dim_key[3:]}", {}).get(
+                        key, _empty_cost_bucket()
                     )
-                elif cost_mode == "events_exact":
-                    by_dim_cost_map: dict[str, dict[str, float]] = {}
-                    if dim_key == "by_agent":
-                        by_dim_cost_map = getattr(j, "llm_cost_by_agent", {})
-                    elif dim_key == "by_component":
-                        by_dim_cost_map = getattr(j, "llm_cost_by_component", {})
-                    elif dim_key == "by_node":
-                        by_dim_cost_map = getattr(j, "llm_cost_by_node", {})
+                    priced_calls = coerce_int(cost_bucket.get("priced_calls"))
+                    total_cost = coerce_float(cost_bucket.get("total_cost_usd"))
+                    prompt_cost, completion_cost, reasoning_cost = bucket_costs(cost_bucket)
 
-                    cost_bucket = by_dim_cost_map.get(key, _empty_cost_bucket())
-                    prompt_cost = float(cost_bucket.get("prompt_cost_usd", 0.0))
-                    completion_cost = float(cost_bucket.get("completion_cost_usd", 0.0))
-                    reasoning_cost = float(cost_bucket.get("reasoning_cost_usd", 0.0))
-
-                total_cost = prompt_cost + completion_cost + reasoning_cost
+                d["priced_calls"] += priced_calls
                 d["cost"] += total_cost
                 d["prompt_cost"] += prompt_cost
                 d["completion_cost"] += completion_cost
                 d["reasoning_cost"] += reasoning_cost
-                if cost_mode == "none":
-                    d["per_run_costs"].append(0.0)
-                else:
-                    d["per_run_costs"].append(total_cost)
+                d["per_run_costs"].append(total_cost)
 
         result = {}
         for key, d in key_data.items():
             result[key] = _build_aggregated_bucket(
                 d["per_run_tokens"], d["per_run_costs"],
-                d["calls"], d["prompt"], d["completion"],
+                d["calls"], d["priced_calls"], d["prompt"], d["completion"],
                 d["reasoning"], d["tokens"], d["cost"],
                 d["prompt_cost"], d["completion_cost"], d["reasoning_cost"],
             )
@@ -1155,9 +1147,9 @@ def compute_aggregated_usage(
 
     return AggregatedUsageResponse(
         totals=totals_bucket,
-        by_model=_aggregate_dimension("by_model", cost_mode="model"),
-        by_agent=_aggregate_dimension("by_agent", cost_mode="events_exact"),
-        by_node=_aggregate_dimension("by_node", cost_mode="events_exact"),
-        by_component=_aggregate_dimension("by_component", cost_mode="events_exact"),
+        by_model=_aggregate_dimension("by_model", cost_source="summary"),
+        by_agent=_aggregate_dimension("by_agent", cost_source="events"),
+        by_node=_aggregate_dimension("by_node", cost_source="events"),
+        by_component=_aggregate_dimension("by_component", cost_source="events"),
         runs_included=len(jobs_with_usage),
     )

--- a/api/metrics/costs.py
+++ b/api/metrics/costs.py
@@ -1,75 +1,133 @@
-"""LLM cost calculation for metrics dashboard."""
+"""LLM cost readout for the metrics dashboard.
+
+Nothing here prices a model. The autodiscovery package records what litellm
+charged for each call at the moment it makes it, into
+``llm_usage_summary.json`` and ``llm_usage_events.jsonl``, so this module only
+adds up a field. That keeps one costing method in play instead of two, and keeps
+litellm -- a heavy dependency, pinned to a different Python than this service --
+out of the API image.
+
+Cost is genuinely unavailable for some runs, and this module reports that rather
+than substituting zero:
+
+- Runs that finished before cost recording landed carry no cost field at all.
+  Their old figures came from a hand-maintained price table and were
+  approximations; showing a gap beats silently mixing two costing methods.
+- Some providers are not billed per token. ``github_copilot`` bills "premium
+  requests", so litellm has no token price for it and no honest dollar figure
+  exists for those calls.
+
+:func:`cost_status` distinguishes the two from a fully-costed run, and the
+dashboard renders each differently.
+"""
 
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
-# Pricing per 1M tokens (USD) — Vertex AI standard pricing
-# Source: https://cloud.google.com/vertex-ai/generative-ai/pricing
-LLM_PRICING: dict[str, dict[str, float]] = {
-    # Google Gemini models
-    "gemini-3.7-flash": {"input": 0.75, "output": 3.75},
-    "gemini-3.1-pro-preview": {"input": 2.00, "output": 12.00},
-    "gemini-3-pro-preview": {"input": 2.00, "output": 12.00},
-    "gemini-3-flash-preview": {"input": 0.50, "output": 3.00},
-    "gemini-2.5-pro": {"input": 1.25, "output": 10.00},
-    "gemini-2.5-pro-preview-05-06": {"input": 1.25, "output": 10.00},
-    "gemini-2.5-flash": {"input": 0.30, "output": 2.50},
-    "gemini-2.5-flash-preview-04-17": {"input": 0.30, "output": 2.50},
-    "gemini-2.0-flash": {"input": 0.15, "output": 0.60},
-    "gemini-2.0-flash-001": {"input": 0.15, "output": 0.60},
-    # OpenAI models
-    "gpt-4o": {"input": 2.50, "output": 10.00},
-    "gpt-4o-2024-08-06": {"input": 2.50, "output": 10.00},
-    "gpt-5-mini": {"input": 0.40, "output": 1.60},
-    "o4-mini": {"input": 1.10, "output": 4.40},
-    "o4-mini-2025-04-16": {"input": 1.10, "output": 4.40},
-    "o3-mini": {"input": 1.10, "output": 4.40},
-}
-
-# Fallback pricing for unknown models (conservative: uses gemini-3.1-pro rates)
-_FALLBACK_PRICING = {"input": 2.00, "output": 12.00}
+#: No recorded call carried a cost.
+UNAVAILABLE = "unavailable"
+#: Some recorded calls carried a cost and some did not; the total is a lower bound.
+PARTIAL = "partial"
+#: Every recorded call carried a cost.
+COMPLETE = "complete"
 
 
-def _lookup_pricing(model_name: str) -> dict[str, float]:
-    """Look up pricing for a model name, stripping provider prefixes."""
-    if model_name in LLM_PRICING:
-        return LLM_PRICING[model_name]
+def coerce_int(value: Any) -> int:
+    """Parse a value into a non-negative int, returning 0 on invalid input."""
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
 
-    # Strip provider prefix (e.g., "google/gemini-3.1-pro-preview" -> "gemini-3.1-pro-preview")
-    stripped = model_name.split("/")[-1] if "/" in model_name else model_name
-    if stripped in LLM_PRICING:
-        return LLM_PRICING[stripped]
 
-    return _FALLBACK_PRICING
+def coerce_float(value: Any) -> float:
+    """Parse a value into a float, returning 0.0 on invalid input."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def bucket_call_counts(bucket: Any) -> tuple[int, int]:
+    """Return (calls, calls that carried a cost) for one usage bucket.
+
+    Args:
+        bucket: A usage bucket from ``llm_usage_summary.json``.
+
+    Returns:
+        Tuple of total calls and the subset of them litellm priced.
+    """
+    if not isinstance(bucket, dict):
+        return 0, 0
+    return coerce_int(bucket.get("calls")), coerce_int(bucket.get("calls_with_cost"))
+
+
+def bucket_costs(bucket: Any) -> tuple[float, float, float]:
+    """Return one bucket's (prompt, completion, reasoning) recorded costs.
+
+    The three parts sum to the bucket's total for calls recorded per response.
+    They are all zero for calls recorded from AG2's running per-agent totals,
+    which know the total but not its split -- so read the total from
+    ``cost_usd`` rather than by adding these up.
+
+    Args:
+        bucket: A usage bucket from ``llm_usage_summary.json``.
+
+    Returns:
+        Tuple of prompt, completion and reasoning cost in USD.
+    """
+    if not isinstance(bucket, dict):
+        return 0.0, 0.0, 0.0
+    return (
+        coerce_float(bucket.get("prompt_cost_usd")),
+        coerce_float(bucket.get("completion_cost_usd")),
+        coerce_float(bucket.get("reasoning_cost_usd")),
+    )
 
 
 def calculate_llm_cost(usage_summary: dict) -> tuple[float, dict[str, float]]:
-    """Calculate LLM cost from a usage summary.
+    """Total the recorded LLM cost of a run, and break it down by model.
 
     Args:
-        usage_summary: The llm_usage_summary.json data with by_model breakdown.
+        usage_summary: The ``llm_usage_summary.json`` data with a ``by_model``
+            breakdown.
 
     Returns:
-        Tuple of (total_cost_usd, {model_name: cost_usd}).
+        Tuple of (total_cost_usd, {model_name: cost_usd}). Models whose calls
+        carried no cost are omitted from the breakdown rather than listed at
+        zero, and contribute nothing to the total.
     """
-    by_model = usage_summary.get("by_model", {})
+    by_model = usage_summary.get("by_model", {}) if isinstance(usage_summary, dict) else {}
     total_cost = 0.0
     cost_by_model: dict[str, float] = {}
 
-    for model_name, usage in by_model.items():
-        pricing = _lookup_pricing(model_name)
-        prompt_tokens = usage.get("prompt_tokens", 0)
-        total_tokens = usage.get("total_tokens", 0)
-        # Use total - prompt to capture all output tokens including reasoning
-        output_tokens = max(0, total_tokens - prompt_tokens)
-        input_cost = (prompt_tokens / 1_000_000) * pricing["input"]
-        output_cost = (output_tokens / 1_000_000) * pricing["output"]
-        model_cost = input_cost + output_cost
+    for model_name, bucket in by_model.items():
+        _, priced_calls = bucket_call_counts(bucket)
+        if not priced_calls:
+            continue
+        model_cost = coerce_float(bucket.get("cost_usd"))
         cost_by_model[model_name] = round(model_cost, 6)
         total_cost += model_cost
 
     return round(total_cost, 6), cost_by_model
+
+
+def cost_status(usage_summary: dict | None) -> str:
+    """Say how much of a run's LLM cost is known.
+
+    Args:
+        usage_summary: The ``llm_usage_summary.json`` data, or None.
+
+    Returns:
+        One of :data:`COMPLETE`, :data:`PARTIAL` or :data:`UNAVAILABLE`.
+    """
+    totals = usage_summary.get("totals", {}) if isinstance(usage_summary, dict) else {}
+    calls, priced_calls = bucket_call_counts(totals)
+    if not priced_calls:
+        return UNAVAILABLE
+    return COMPLETE if priced_calls >= calls else PARTIAL
 
 
 def get_duration_seconds(created_at: str | None, finished_at: str | None) -> float | None:

--- a/api/metrics/models.py
+++ b/api/metrics/models.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+from .costs import COMPLETE, PARTIAL, UNAVAILABLE
+
+#: How much of a run's LLM cost is known. See :mod:`api.metrics.costs`.
+LLMCostStatus = Literal[COMPLETE, PARTIAL, UNAVAILABLE]
 
 
 class DailyMetrics(BaseModel):
@@ -32,6 +37,9 @@ class OverviewMetrics(BaseModel):
     total_experiments_requested: int = Field(0)
     experiment_completion_rate: float = Field(0.0)
     llm_cost_usd: float = Field(0.0)
+    runs_missing_cost: int = Field(
+        0, description="Runs contributing no cost, so the total is a lower bound"
+    )
     # Cost-per-hypothesis breakdown (only jobs with LLM usage data)
     hypotheses_with_usage: int = Field(0, description="Completed experiments from runs with LLM usage data")
     cost_per_hypothesis_usd: float | None = Field(None)
@@ -55,6 +63,9 @@ class UserMetricsSummary(BaseModel):
     success_rate: float = Field(0.0)
     total_experiments: int = Field(0)
     llm_cost_usd: float = Field(0.0)
+    runs_missing_cost: int = Field(
+        0, description="Runs contributing no cost, so the total is a lower bound"
+    )
     shared_runs: int = Field(0)
     last_activity: str | None = Field(None, description="Most recent run created_at")
 
@@ -83,6 +94,7 @@ class RunSummary(BaseModel):
     is_shared: bool = Field(False)
     model: str | None = None
     llm_cost_usd: float = Field(0.0)
+    llm_cost_status: LLMCostStatus = Field(UNAVAILABLE)
 
 
 class LLMUsageSummary(BaseModel):
@@ -108,6 +120,7 @@ class RunMetrics(BaseModel):
     duration_seconds: float | None = None
     llm_usage_summary: LLMUsageSummary | None = None
     llm_cost_usd: float = Field(0.0)
+    llm_cost_status: LLMCostStatus = Field(UNAVAILABLE)
     llm_cost_by_model: dict[str, float] = Field(default_factory=dict)
     n_experiments_requested: int = Field(0)
     n_experiments_completed: int = Field(0)
@@ -119,6 +132,7 @@ class AggregatedUsageBucket(BaseModel):
     """Aggregated LLM usage with statistics across runs."""
 
     total_calls: int = Field(0)
+    priced_calls: int = Field(0, description="Of total_calls, how many carried a cost")
     total_prompt_tokens: int = Field(0)
     total_completion_tokens: int = Field(0)
     total_reasoning_tokens: int = Field(0)

--- a/api/tests/test_aggregator_costs.py
+++ b/api/tests/test_aggregator_costs.py
@@ -1,0 +1,117 @@
+"""Tests for per-event cost breakdowns built by the metrics aggregator."""
+
+import pytest
+from metrics import aggregator
+
+
+def _event(
+    *,
+    agent_name: str | None,
+    component: str,
+    node_id: str | None,
+    cost: dict | None,
+) -> dict:
+    return {
+        "source": "openai",
+        "component": component,
+        "agent_name": agent_name,
+        "node_id": node_id,
+        "model": "openai/gpt-4o",
+        "cost": cost,
+        "usage": {"prompt_tokens": 1000, "completion_tokens": 500, "total_tokens": 1500},
+    }
+
+
+def test_event_cost_breakdowns_sum_recorded_costs_by_agent_component_and_node() -> None:
+    events = [
+        _event(
+            agent_name="belief_agent",
+            component="belief.main.prior",
+            node_id="node_2_0",
+            cost={
+                "total_usd": 0.75,
+                "prompt_usd": 0.25,
+                "completion_usd": 0.3,
+                "reasoning_usd": 0.2,
+            },
+        ),
+        _event(
+            agent_name="belief_agent",
+            component="belief.main.posterior",
+            node_id="node_2_0",
+            cost={
+                "total_usd": 0.25,
+                "prompt_usd": 0.1,
+                "completion_usd": 0.15,
+                "reasoning_usd": 0.0,
+            },
+        ),
+    ]
+
+    by_agent, by_component, by_node = aggregator._build_event_cost_breakdowns(events)
+
+    assert by_agent["belief_agent"] == pytest.approx(
+        {
+            "total_cost_usd": 1.0,
+            "prompt_cost_usd": 0.35,
+            "completion_cost_usd": 0.45,
+            "reasoning_cost_usd": 0.2,
+            "calls": 2,
+            "priced_calls": 2,
+        }
+    )
+    # Both events share an agent and a node, so only the component splits them.
+    assert by_node["node_2_0"] == by_agent["belief_agent"]
+    assert by_component["belief.main.prior"]["total_cost_usd"] == 0.75
+    assert by_component["belief.main.posterior"]["total_cost_usd"] == 0.25
+    assert by_component["belief.main.prior"]["calls"] == 1
+
+
+def test_event_cost_breakdowns_count_unpriced_calls_separately() -> None:
+    """priced_calls below calls is what marks a bucket's total as a lower bound."""
+    events = [
+        _event(
+            agent_name="belief_agent",
+            component="belief.main.prior",
+            node_id="node_2_0",
+            cost={"total_usd": 0.75, "prompt_usd": 0.25, "completion_usd": 0.5},
+        ),
+        _event(
+            agent_name="belief_agent",
+            component="belief.main.prior",
+            node_id="node_2_0",
+            cost=None,
+        ),
+    ]
+
+    by_agent, _, _ = aggregator._build_event_cost_breakdowns(events)
+
+    assert by_agent["belief_agent"]["calls"] == 2
+    assert by_agent["belief_agent"]["priced_calls"] == 1
+    assert by_agent["belief_agent"]["total_cost_usd"] == 0.75
+    assert by_agent["belief_agent"]["reasoning_cost_usd"] == 0.0
+
+
+def test_event_cost_breakdowns_fall_back_to_placeholder_keys() -> None:
+    events = [_event(agent_name=None, component="", node_id=None, cost=None)]
+
+    by_agent, by_component, by_node = aggregator._build_event_cost_breakdowns(events)
+
+    assert set(by_agent) == {"unassigned"}
+    assert set(by_component) == {"unknown"}
+    assert set(by_node) == {"run_level"}
+    assert by_agent["unassigned"]["calls"] == 1
+    assert by_agent["unassigned"]["priced_calls"] == 0
+
+
+def test_event_cost_reads_only_a_cost_with_a_total() -> None:
+    """A legacy event has no cost key at all; a malformed one has no total."""
+    assert aggregator._event_cost({"cost": None}) is None
+    assert aggregator._event_cost({}) is None
+    assert aggregator._event_cost({"cost": {"prompt_usd": 0.25}}) is None
+    assert aggregator._event_cost({"cost": {"total_usd": 0.25}}) == {
+        "total_cost_usd": 0.25,
+        "prompt_cost_usd": 0.0,
+        "completion_cost_usd": 0.0,
+        "reasoning_cost_usd": 0.0,
+    }

--- a/api/tests/test_costs.py
+++ b/api/tests/test_costs.py
@@ -1,0 +1,131 @@
+"""Tests for the dashboard's LLM cost readout."""
+
+from metrics import costs
+
+
+def _bucket(calls: int, calls_with_cost: int, **cost_fields: float) -> dict:
+    """One post-change bucket as ``llm_usage_summary.json`` writes it."""
+    bucket = {
+        "calls": calls,
+        "prompt_tokens": 1000 * calls,
+        "completion_tokens": 500 * calls,
+        "total_tokens": 1500 * calls,
+        "reasoning_tokens": 0,
+        "calls_with_cost": calls_with_cost,
+        "cost_usd": 0.0,
+        "prompt_cost_usd": 0.0,
+        "completion_cost_usd": 0.0,
+        "reasoning_cost_usd": 0.0,
+    }
+    bucket.update(cost_fields)
+    return bucket
+
+
+def _legacy_bucket(calls: int) -> dict:
+    """One bucket as runs that predate cost recording wrote it: tokens only.
+
+    Backwards compatibility is the point of this shape -- those runs carry no
+    cost field at all, and their old figures came from a hand-maintained price
+    table, so the dashboard must show a gap rather than a zero.
+    """
+    return {
+        "calls": calls,
+        "prompt_tokens": 1000 * calls,
+        "completion_tokens": 500 * calls,
+        "total_tokens": 1500 * calls,
+        "reasoning_tokens": 0,
+    }
+
+
+def test_calculate_llm_cost_sums_recorded_cost_by_model() -> None:
+    summary = {
+        "totals": _bucket(5, 5, cost_usd=0.75),
+        "by_model": {
+            "openai/gpt-4o": _bucket(3, 3, cost_usd=0.5),
+            "vertex_ai/gemini-2.5-pro": _bucket(2, 2, cost_usd=0.25),
+        },
+    }
+
+    total, by_model = costs.calculate_llm_cost(summary)
+
+    assert total == 0.75
+    assert by_model == {"openai/gpt-4o": 0.5, "vertex_ai/gemini-2.5-pro": 0.25}
+
+
+def test_calculate_llm_cost_omits_a_model_whose_calls_were_never_priced() -> None:
+    """Copilot calls are unpriced, not free; listing them at $0 would be a lie."""
+    summary = {
+        "by_model": {
+            "openai/gpt-4o": _bucket(3, 3, cost_usd=0.5),
+            "github_copilot/gpt-4o": _bucket(40, 0),
+        },
+    }
+
+    total, by_model = costs.calculate_llm_cost(summary)
+
+    assert total == 0.5
+    assert by_model == {"openai/gpt-4o": 0.5}
+    assert "github_copilot/gpt-4o" not in by_model
+
+
+def test_calculate_llm_cost_handles_a_summary_with_no_by_model() -> None:
+    assert costs.calculate_llm_cost({}) == (0.0, {})
+    assert costs.calculate_llm_cost({"by_model": {}}) == (0.0, {})
+
+
+def test_calculate_llm_cost_rounds_to_the_cent_fraction_it_displays() -> None:
+    summary = {"by_model": {"openai/gpt-4o": _bucket(1, 1, cost_usd=0.12345678)}}
+
+    total, by_model = costs.calculate_llm_cost(summary)
+
+    assert total == 0.123457
+    assert by_model == {"openai/gpt-4o": 0.123457}
+
+
+def test_cost_status_is_unavailable_for_a_run_that_predates_cost_recording() -> None:
+    """The backwards-compatibility guarantee: no cost fields means no cost, not $0."""
+    legacy_summary = {
+        "totals": _legacy_bucket(5),
+        "by_model": {"openai/gpt-4o": _legacy_bucket(5)},
+        "by_agent": {"belief_agent": _legacy_bucket(5)},
+        "by_node": {"node_2_0": _legacy_bucket(5)},
+        "by_component": {"belief.main.prior": _legacy_bucket(5)},
+    }
+
+    assert costs.cost_status(legacy_summary) == costs.UNAVAILABLE
+    assert costs.calculate_llm_cost(legacy_summary) == (0.0, {})
+
+
+def test_cost_status_is_unavailable_when_no_call_was_priced() -> None:
+    assert costs.cost_status({"totals": _bucket(40, 0)}) == costs.UNAVAILABLE
+    assert costs.cost_status(None) == costs.UNAVAILABLE
+    assert costs.cost_status({}) == costs.UNAVAILABLE
+
+
+def test_cost_status_is_complete_when_every_call_was_priced() -> None:
+    assert costs.cost_status({"totals": _bucket(5, 5, cost_usd=0.75)}) == costs.COMPLETE
+
+
+def test_cost_status_is_partial_when_only_some_calls_were_priced() -> None:
+    """A mixed-provider run knows part of its bill; the total is a lower bound."""
+    assert costs.cost_status({"totals": _bucket(45, 5, cost_usd=0.75)}) == costs.PARTIAL
+
+
+def test_bucket_call_counts_and_costs_tolerate_a_missing_bucket() -> None:
+    assert costs.bucket_call_counts(None) == (0, 0)
+    assert costs.bucket_call_counts(_legacy_bucket(5)) == (5, 0)
+    assert costs.bucket_costs(None) == (0.0, 0.0, 0.0)
+    assert costs.bucket_costs(_legacy_bucket(5)) == (0.0, 0.0, 0.0)
+    assert costs.bucket_costs(
+        _bucket(1, 1, cost_usd=0.75, prompt_cost_usd=0.25, completion_cost_usd=0.4)
+    ) == (0.25, 0.4, 0.0)
+
+
+def test_coercion_falls_back_to_zero_on_junk() -> None:
+    assert costs.coerce_int("7") == 7
+    assert costs.coerce_int(-3) == 0
+    assert costs.coerce_int(None) == 0
+    assert costs.coerce_int("nope") == 0
+    assert costs.coerce_float("0.25") == 0.25
+    assert costs.coerce_float(None) == 0.0
+    assert costs.coerce_float("nope") == 0.0

--- a/packages/autodiscovery/src/autodiscovery/agents.py
+++ b/packages/autodiscovery/src/autodiscovery/agents.py
@@ -145,6 +145,7 @@ class ModalSandboxExecutor(CodeExecutor):
             self._usage_tracker.record_response(
                 response,
                 source=llm.provider_of(self.vision_model),
+                request_model=self.vision_model,
                 component="image_analysis.modal",
                 agent_name="code_executor",
                 node_id=self._usage_node_id,
@@ -356,6 +357,9 @@ def image_to_text():
                     'prompt_tokens': getattr(usage, 'prompt_tokens', 0) or 0,
                     'completion_tokens': getattr(usage, 'completion_tokens', 0) or 0,
                     'total_tokens': getattr(usage, 'total_tokens', 0) or 0,
+                    # The response is only reachable in here, so the cost is
+                    # priced sandbox-side and carried out through the marker.
+                    'cost': llm.cost_of(response, VISION_MODEL),
                 }, sort_keys=True))
             print("\\n=== Plot Analysis (fig. {{}}) ===\\n".format(fig_num))
             print(response.choices[0].message.content)
@@ -481,7 +485,11 @@ class LiteLLMAG2Client:
         response = llm.complete(self.model, params["messages"], **kwargs)
         # This is the single point every AG2 response flows through, so usage is
         # recorded here rather than by patching AG2's OpenAIWrapper.
-        record_ag2_response_usage(response, agent_name=self.config.get("agent_name"))
+        record_ag2_response_usage(
+            response,
+            agent_name=self.config.get("agent_name"),
+            request_model=self.model,
+        )
         return response
 
     def message_retrieval(self, response: Any) -> list[str]:
@@ -490,17 +498,22 @@ class LiteLLMAG2Client:
 
     def cost(self, response: Any) -> float:
         """Return the response cost litellm computed, or zero."""
-        return float(getattr(response, "_hidden_params", {}).get("response_cost") or 0.0)
+        return llm.reported_cost(response) or 0.0
 
     @staticmethod
     def get_usage(response: Any) -> dict[str, Any]:
-        """Return AG2-compatible token usage metadata."""
+        """Return AG2-compatible token usage metadata.
+
+        AG2's interface requires a number, so an unpriced model reports zero
+        here. The usage tracker keeps the distinction between free and unpriced
+        that this loses; see :func:`autodiscovery.llm.cost_of`.
+        """
         usage = getattr(response, "usage", None)
         return {
             "prompt_tokens": getattr(usage, "prompt_tokens", 0) or 0,
             "completion_tokens": getattr(usage, "completion_tokens", 0) or 0,
             "total_tokens": getattr(usage, "total_tokens", 0) or 0,
-            "cost": float(getattr(response, "_hidden_params", {}).get("response_cost") or 0.0),
+            "cost": llm.reported_cost(response) or 0.0,
             "model": getattr(response, "model", None),
         }
 

--- a/packages/autodiscovery/src/autodiscovery/deduplication.py
+++ b/packages/autodiscovery/src/autodiscovery/deduplication.py
@@ -173,6 +173,7 @@ def get_embedding(
                     usage_tracker.record_response(
                         response,
                         source=llm.provider_of(model),
+                        request_model=model,
                         component="dedupe.embeddings",
                         agent_name="dedupe",
                     )

--- a/packages/autodiscovery/src/autodiscovery/llm.py
+++ b/packages/autodiscovery/src/autodiscovery/llm.py
@@ -336,6 +336,120 @@ def validate(
         )
 
 
+def reported_cost(response: Any) -> float | None:
+    """Return the cost litellm computed for a response, if it computed one.
+
+    This is the only place ``_hidden_params`` is read. litellm sets
+    ``response_cost`` on every response it returns, derived from its own
+    maintained per-model prices.
+
+    Args:
+        response: A litellm response object.
+
+    Returns:
+        The cost in USD, or None when litellm did not price the call.
+    """
+    hidden = getattr(response, "_hidden_params", None)
+    if not isinstance(hidden, dict):
+        return None
+    try:
+        cost = hidden.get("response_cost")
+        return None if cost is None else float(cost)
+    except (TypeError, ValueError):
+        return None
+
+
+def cost_of(response: Any, model: str) -> dict[str, float] | None:
+    """Return litellm's cost for one response, split by token type.
+
+    litellm computes the cost of every call it makes and hangs it on the
+    response as ``_hidden_params["response_cost"]``; that figure is
+    authoritative here and is never recomputed. The prompt/completion split is
+    not on the response, so it comes from ``litellm.cost_per_token`` and is then
+    scaled onto the authoritative total -- ``response_cost`` also covers cache
+    reads, image input and built-in tools, which a plain prompt/completion split
+    does not, so the two disagree on some calls and the total is the one to keep.
+
+    None means the cost is *unknown*, which is the honest answer for a model
+    litellm has no prices for and is not the same as a cost of zero. Two cases
+    reach it: a model litellm has not mapped yet, which preview models routinely
+    are, and a provider that does not bill per token at all -- ``github_copilot``
+    bills "premium requests", and litellm reports every one of its models at a
+    zero token price, so a per-token figure for it would be fiction.
+
+    Args:
+        response: A litellm ``ModelResponse`` or ``EmbeddingResponse``.
+        model: The litellm-qualified model name the request was made with.
+
+    Returns:
+        Mapping with ``total_usd`` and, when the split is derivable,
+        ``prompt_usd``, ``completion_usd`` and ``reasoning_usd`` -- which sum to
+        ``total_usd``. None when the model cannot be priced.
+    """
+    total = reported_cost(response)
+    usage = getattr(response, "usage", None)
+    prompt_tokens = _usage_int(usage, "prompt_tokens")
+    completion_tokens = _usage_int(usage, "completion_tokens")
+    # Reasoning tokens are a subset of completion_tokens in the OpenAI usage
+    # shape litellm normalizes to, not an addition to them.
+    reasoning_tokens = min(
+        completion_tokens,
+        _usage_int(_usage_get(usage, "completion_tokens_details"), "reasoning_tokens"),
+    )
+
+    try:
+        prompt_usd, completion_usd = _configure().cost_per_token(
+            model=model.split("/", 1)[1],
+            custom_llm_provider=provider_of(model),
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+        )
+    except Exception:
+        # litellm has not mapped the model, so it has no prices for it.
+        return None
+    split_total = float(prompt_usd) + float(completion_usd)
+    if total is None:
+        total = split_total
+
+    if total <= 0:
+        # A priced call over a non-empty prompt always costs something, so zero
+        # here means an unpriced model rather than a free one.
+        return None if prompt_tokens + completion_tokens > 0 else {"total_usd": 0.0}
+    if split_total <= 0:
+        return {"total_usd": total}
+
+    scale = total / split_total
+    prompt_usd = float(prompt_usd) * scale
+    completion_usd = float(completion_usd) * scale
+    # Reasoning tokens bill at the output rate, so reporting them separately is
+    # a share of the completion cost rather than a price of their own.
+    reasoning_usd = (
+        completion_usd * (reasoning_tokens / completion_tokens) if completion_tokens else 0.0
+    )
+    return {
+        "total_usd": total,
+        "prompt_usd": prompt_usd,
+        "completion_usd": completion_usd - reasoning_usd,
+        "reasoning_usd": reasoning_usd,
+    }
+
+
+def _usage_get(usage: Any, key: str) -> Any:
+    """Read a field off a usage payload, dict-like or object-like."""
+    if isinstance(usage, dict):
+        return usage.get(key)
+    return getattr(usage, key, None)
+
+
+def _usage_int(usage: Any, key: str) -> int:
+    """Read a non-negative token count off a usage payload, dict-like or not."""
+    value = _usage_get(usage, key)
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
 def _provider_kwargs(model: str) -> dict[str, Any]:
     """Return provider-scoped kwargs for a litellm call."""
     if provider_of(model) != VERTEX_AI:

--- a/packages/autodiscovery/src/autodiscovery/llm.py
+++ b/packages/autodiscovery/src/autodiscovery/llm.py
@@ -384,7 +384,7 @@ def cost_of(response: Any, model: str) -> dict[str, float] | None:
     Returns:
         Mapping with ``total_usd`` and, when the split is derivable,
         ``prompt_usd``, ``completion_usd`` and ``reasoning_usd`` -- which sum to
-        ``total_usd``. None when the model cannot be priced.
+        ``total_usd`` up to float precision. None when the model cannot be priced.
     """
     total = reported_cost(response)
     usage = getattr(response, "usage", None)

--- a/packages/autodiscovery/src/autodiscovery/llm_usage.py
+++ b/packages/autodiscovery/src/autodiscovery/llm_usage.py
@@ -125,6 +125,7 @@ class UsageTracker:
         node_id: str | None = None,
         metadata: dict[str, Any] | None = None,
         usage: Any | None = None,
+        cost: dict[str, float] | None = None,
     ) -> dict[str, Any]:
         """Record one token-usage event.
 
@@ -139,6 +140,9 @@ class UsageTracker:
             node_id: Optional node identifier.
             metadata: Optional metadata map.
             usage: Optional raw provider usage payload in standardized response form.
+            cost: Optional cost breakdown, as returned by
+                :func:`autodiscovery.llm.cost_of`. ``None`` records the call's cost
+                as unavailable, which is not the same as a cost of zero.
 
         Returns:
             The recorded event dictionary.
@@ -155,6 +159,7 @@ class UsageTracker:
             "node_id": node_id,
             "model": model,
             "metadata": metadata or {},
+            "cost": _normalize_cost(cost),
         }
         usage_payload = _usage_payload_with_token_counts(
             usage=usage,
@@ -173,6 +178,7 @@ class UsageTracker:
         *,
         source: str,
         component: str,
+        request_model: str | None = None,
         agent_name: str | None = None,
         node_id: str | None = None,
         metadata: dict[str, Any] | None = None,
@@ -183,6 +189,10 @@ class UsageTracker:
             response: API response object that may contain ``usage`` and ``model``.
             source: Source identifier.
             component: Component label for the call path.
+            request_model: The litellm-qualified model name the request was made
+                with. Supplying it records what the call cost; without it the
+                event's cost is unavailable, because pricing a call needs the
+                provider and a response only reports the bare model name.
             agent_name: Optional agent name.
             node_id: Optional node identifier.
             metadata: Optional metadata map.
@@ -204,6 +214,7 @@ class UsageTracker:
             node_id=node_id,
             metadata=dict(metadata or {}),
             usage=usage.get("usage"),
+            cost=_response_cost(response, request_model),
         )
 
     def record_agent_usage_deltas(
@@ -251,6 +262,7 @@ class UsageTracker:
                     total_tokens=total,
                     agent_name=agent_name,
                     node_id=node_id,
+                    cost=_delta_cost(model_usage, prev_usage),
                 )
 
     def get_node_summary(self, node_id: str) -> dict[str, Any]:
@@ -352,12 +364,14 @@ def record_ag2_response_usage(
     response: Any,
     *,
     agent_name: str | None = None,
+    request_model: str | None = None,
 ) -> dict[str, Any] | None:
     """Record one AG2 response usage event using configured global context.
 
     Args:
         response: OpenAI-compatible response returned by AG2.
         agent_name: Optional agent name for attribution.
+        request_model: The litellm-qualified model name the request was made with.
 
     Returns:
         The recorded event dictionary, or ``None`` if tracking is disabled or
@@ -372,6 +386,7 @@ def record_ag2_response_usage(
         response,
         source="ag2",
         component=component,
+        request_model=request_model,
         agent_name=agent_name,
         node_id=node_id,
     )
@@ -406,6 +421,18 @@ def _accumulate(target: dict[str, Any], event: dict[str, Any], key: str | None =
     bucket["total_tokens"] += total
     bucket["reasoning_tokens"] += reasoning
 
+    cost = event.get("cost")
+    if not isinstance(cost, dict):
+        return
+    # Counted separately from ``calls`` so a consumer can tell "these calls cost
+    # nothing" from "nobody knows what these calls cost" -- the two are only
+    # distinguishable at this granularity, and a bucket may hold both.
+    bucket["calls_with_cost"] += 1
+    bucket["cost_usd"] += float(cost.get("total_usd") or 0.0)
+    bucket["prompt_cost_usd"] += float(cost.get("prompt_usd") or 0.0)
+    bucket["completion_cost_usd"] += float(cost.get("completion_usd") or 0.0)
+    bucket["reasoning_cost_usd"] += float(cost.get("reasoning_usd") or 0.0)
+
 
 def _empty_bucket() -> dict[str, Any]:
     """Return an empty aggregate bucket."""
@@ -415,7 +442,73 @@ def _empty_bucket() -> dict[str, Any]:
         "completion_tokens": 0,
         "total_tokens": 0,
         "reasoning_tokens": 0,
+        "calls_with_cost": 0,
+        "cost_usd": 0.0,
+        "prompt_cost_usd": 0.0,
+        "completion_cost_usd": 0.0,
+        "reasoning_cost_usd": 0.0,
     }
+
+
+def _normalize_cost(cost: dict[str, float] | None) -> dict[str, float] | None:
+    """Coerce a cost breakdown into JSON-safe floats, or None if unusable."""
+    if not isinstance(cost, dict):
+        return None
+    normalized: dict[str, float] = {}
+    for key in ("total_usd", "prompt_usd", "completion_usd", "reasoning_usd"):
+        if cost.get(key) is None:
+            continue
+        try:
+            normalized[key] = round(float(cost[key]), 12)
+        except (TypeError, ValueError):
+            continue
+    return normalized if "total_usd" in normalized else None
+
+
+def _response_cost(response: Any, request_model: str | None) -> dict[str, float] | None:
+    """Price one response via litellm, or None when it cannot be priced."""
+    if not request_model:
+        return None
+    # Imported here rather than at module scope: this module is also loaded by
+    # the code-executor sandbox, where paying litellm's import cost to track
+    # tokens would be wasted.
+    from autodiscovery import llm
+
+    try:
+        return llm.cost_of(response, request_model)
+    except Exception:
+        # Usage tracking is bookkeeping around a call that already succeeded.
+        # An unpriceable model reports an unavailable cost, it does not fail the run.
+        return None
+
+
+def _delta_cost(
+    model_usage: dict[str, Any],
+    previous_usage: dict[str, Any],
+) -> dict[str, float] | None:
+    """Get the cost delta between two AG2 per-model usage summaries.
+
+    AG2 records the per-call cost :meth:`LiteLLMAG2Client.get_usage` hands it,
+    which is litellm's own figure, but only as a running total -- so this yields
+    a total with no prompt/completion split, unlike the per-response path.
+
+    Args:
+        model_usage: The later AG2 usage summary for one model.
+        previous_usage: The earlier summary for the same model.
+
+    Returns:
+        ``{"total_usd": delta}``, or None when the cost is unavailable.
+    """
+    if model_usage.get("cost") is None:
+        return None
+    try:
+        delta = float(model_usage["cost"]) - float(previous_usage.get("cost") or 0.0)
+    except (TypeError, ValueError):
+        return None
+    # A priced call always costs something, and this only runs for a window that
+    # did consume tokens -- so a zero delta means the model is unpriced (AG2's
+    # interface forced it to zero) rather than that the calls were free.
+    return {"total_usd": delta} if delta > 0 else None
 
 def _extract_usage_from_response(response: Any) -> dict[str, Any] | None:
     """Extract common usage fields from API responses."""

--- a/packages/autodiscovery/src/autodiscovery/llm_usage.py
+++ b/packages/autodiscovery/src/autodiscovery/llm_usage.py
@@ -510,6 +510,7 @@ def _delta_cost(
     # interface forced it to zero) rather than that the calls were free.
     return {"total_usd": delta} if delta > 0 else None
 
+
 def _extract_usage_from_response(response: Any) -> dict[str, Any] | None:
     """Extract common usage fields from API responses."""
     usage_obj = getattr(response, "usage", None)

--- a/packages/autodiscovery/src/autodiscovery/run.py
+++ b/packages/autodiscovery/src/autodiscovery/run.py
@@ -659,6 +659,7 @@ def run_mcts(
                                 total_tokens=usage_entry.get("total_tokens"),
                                 agent_name=usage_entry.get("agent_name", "code_executor"),
                                 node_id=node.id,
+                                cost=usage_entry.get("cost"),
                             )
                         node.code_output = cleaned_output
                     rich_outputs = _get_executor_rich_outputs(agent_objs["code_executor"])

--- a/packages/autodiscovery/src/autodiscovery/utils.py
+++ b/packages/autodiscovery/src/autodiscovery/utils.py
@@ -89,6 +89,7 @@ def query_llm(
             usage_tracker.record_response(
                 response,
                 source=llm.provider_of(model),
+                request_model=model,
                 component=usage_component,
                 agent_name=usage_agent_name,
                 node_id=usage_node_id,

--- a/packages/autodiscovery/tests/test_llm_cost.py
+++ b/packages/autodiscovery/tests/test_llm_cost.py
@@ -1,0 +1,170 @@
+"""Tests for per-call cost reporting from litellm."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from autodiscovery.llm import cost_of, reported_cost
+
+# Prices come from litellm's registry and drift with it, so nothing here asserts
+# a per-token rate. The invariants are what the callers rely on: the total is
+# whatever litellm reported for the call, and the split adds back up to it.
+#
+# The split is scaled onto the reported total, so "adds back up" is exact only
+# to float precision; EXACT pins that at a relative 1e-12 rather than letting a
+# real drift hide behind a loose tolerance.
+EXACT = 1e-12
+
+
+def _response(
+    *,
+    response_cost: float | None,
+    prompt_tokens: int,
+    completion_tokens: int,
+    reasoning_tokens: int | None = None,
+) -> SimpleNamespace:
+    completion_details = (
+        {"reasoning_tokens": reasoning_tokens} if reasoning_tokens is not None else None
+    )
+    return SimpleNamespace(
+        usage=SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+            completion_tokens_details=completion_details,
+        ),
+        model="gpt-4o",
+        _hidden_params={} if response_cost is None else {"response_cost": response_cost},
+    )
+
+
+def _parts_sum(cost: dict[str, float]) -> float:
+    return cost["prompt_usd"] + cost["completion_usd"] + cost["reasoning_usd"]
+
+
+def test_priced_model_reports_litellms_total_and_a_split_that_sums_to_it() -> None:
+    response = _response(response_cost=0.0075, prompt_tokens=1000, completion_tokens=500)
+
+    cost = cost_of(response, "openai/gpt-4o")
+
+    assert cost is not None
+    # The total is litellm's own figure, never recomputed from token prices.
+    assert cost["total_usd"] == 0.0075
+    assert _parts_sum(cost) == pytest.approx(0.0075, rel=EXACT)
+    assert cost["prompt_usd"] > 0
+    assert cost["completion_usd"] > 0
+    assert cost["reasoning_usd"] == 0.0
+
+
+def test_copilot_reports_unknown_rather_than_zero() -> None:
+    """Copilot bills premium requests, so litellm's zero token price is not a price.
+
+    This is the regression the whole cost-recording change exists to prevent:
+    reporting a real run as free because the provider is not billed per token.
+    """
+    response = _response(response_cost=0.0, prompt_tokens=1000, completion_tokens=500)
+
+    assert cost_of(response, "github_copilot/gpt-4o") is None
+    assert cost_of(response, "github_copilot/claude-haiku-4.5") is None
+
+
+def test_model_litellm_has_not_mapped_reports_unknown() -> None:
+    """Preview models ship before litellm prices them; that is unknown, not free."""
+    response = _response(response_cost=0.01, prompt_tokens=1000, completion_tokens=500)
+
+    assert cost_of(response, "vertex_ai/gemini-4.7-pro-preview") is None
+
+
+def test_reasoning_cost_is_carved_out_of_the_completion_cost() -> None:
+    """Reasoning tokens are a subset of completion tokens, not an addition to them."""
+    response = _response(
+        response_cost=0.0022,
+        prompt_tokens=1000,
+        completion_tokens=500,
+        reasoning_tokens=400,
+    )
+
+    cost = cost_of(response, "openai/o4-mini")
+
+    assert cost is not None
+    assert cost["total_usd"] == 0.0022
+    assert _parts_sum(cost) == pytest.approx(0.0022, rel=EXACT)
+    # 400 of the 500 completion tokens were reasoning, so reasoning takes 4/5 of
+    # the completion cost and the remaining completion_usd keeps the other 1/5.
+    output_usd = cost["completion_usd"] + cost["reasoning_usd"]
+    assert cost["reasoning_usd"] == pytest.approx(output_usd * 0.8, rel=EXACT)
+    assert cost["completion_usd"] == pytest.approx(output_usd * 0.2, rel=EXACT)
+
+
+def test_reasoning_tokens_are_clamped_to_the_completion_count() -> None:
+    """A reasoning count above completion_tokens must not exceed the output cost."""
+    response = _response(
+        response_cost=0.0022,
+        prompt_tokens=1000,
+        completion_tokens=500,
+        reasoning_tokens=900,
+    )
+
+    cost = cost_of(response, "openai/o4-mini")
+
+    assert cost is not None
+    assert _parts_sum(cost) == pytest.approx(0.0022, rel=EXACT)
+    assert cost["completion_usd"] == 0.0
+
+
+def test_a_discounted_total_keeps_litellms_figure_and_rescales_the_split() -> None:
+    """A cache read makes response_cost lower than a plain prompt/completion split.
+
+    ``response_cost`` also covers cache reads, image input and built-in tools, so
+    the two disagree on some calls; the reported total wins and the split is
+    scaled onto it.
+    """
+    tokens = {"prompt_tokens": 1000, "completion_tokens": 500}
+    undiscounted = cost_of(_response(response_cost=0.0075, **tokens), "openai/gpt-4o")
+    discounted = cost_of(_response(response_cost=0.002, **tokens), "openai/gpt-4o")
+
+    assert undiscounted is not None
+    assert discounted is not None
+    assert discounted["total_usd"] == 0.002
+    assert _parts_sum(discounted) == pytest.approx(0.002, rel=EXACT)
+    # Same tokens, so the split keeps its shape and only its scale changes.
+    assert discounted["total_usd"] < undiscounted["total_usd"]
+    assert discounted["prompt_usd"] / discounted["completion_usd"] == pytest.approx(
+        undiscounted["prompt_usd"] / undiscounted["completion_usd"], rel=EXACT
+    )
+
+
+def test_a_zero_token_call_is_free_rather_than_unpriced() -> None:
+    """Zero cost over zero tokens is a real answer; zero over real tokens is not."""
+    response = _response(response_cost=0.0, prompt_tokens=0, completion_tokens=0)
+
+    assert cost_of(response, "openai/gpt-4o") == {"total_usd": 0.0}
+
+
+def test_reported_cost_is_none_without_hidden_params() -> None:
+    assert reported_cost(SimpleNamespace(model="gpt-4o")) is None
+    assert reported_cost(SimpleNamespace(model="gpt-4o", _hidden_params={})) is None
+    assert reported_cost(SimpleNamespace(_hidden_params={"response_cost": None})) is None
+    assert reported_cost(SimpleNamespace(_hidden_params={"response_cost": 0.25})) == 0.25
+
+
+def test_cost_of_falls_back_to_the_token_split_when_nothing_was_reported() -> None:
+    """A response with no ``response_cost`` is still priceable from its tokens."""
+    reported = cost_of(
+        _response(response_cost=0.0075, prompt_tokens=1000, completion_tokens=500),
+        "openai/gpt-4o",
+    )
+    unreported = cost_of(
+        _response(response_cost=None, prompt_tokens=1000, completion_tokens=500),
+        "openai/gpt-4o",
+    )
+
+    assert reported is not None
+    assert unreported is not None
+    assert _parts_sum(unreported) == pytest.approx(unreported["total_usd"], rel=EXACT)
+    # 0.0075 is exactly litellm's own gpt-4o split for these tokens today, so the
+    # fallback and the reported figure agree; assert the relationship, not a rate.
+    assert unreported["prompt_usd"] / unreported["completion_usd"] == pytest.approx(
+        reported["prompt_usd"] / reported["completion_usd"], rel=EXACT
+    )

--- a/packages/autodiscovery/tests/test_llm_usage.py
+++ b/packages/autodiscovery/tests/test_llm_usage.py
@@ -305,3 +305,213 @@ def test_query_llm_keeps_minimal_reasoning_effort_for_gpt5(transport) -> None:
     )
 
     assert transport.calls[0]["reasoning_effort"] == "minimal"
+
+
+# --- cost recording --------------------------------------------------------
+
+
+class _FakePricedResponse:
+    """Stand-in for a litellm response, which carries its cost in _hidden_params."""
+
+    def __init__(
+        self,
+        model: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        response_cost: float,
+    ):
+        self.model = model
+        self.usage = _FakeUsage(prompt_tokens, completion_tokens, prompt_tokens + completion_tokens)
+        self._hidden_params = {"response_cost": response_cost}
+
+
+def _cost_fields(bucket: dict) -> dict:
+    return {key: bucket[key] for key in bucket if key.endswith("_usd") or key == "calls_with_cost"}
+
+
+def test_record_event_aggregates_cost_into_every_breakdown() -> None:
+    """A recorded cost lands in totals and in each keyed breakdown alike."""
+    tracker = UsageTracker()
+    tracker.record_event(
+        source="openai",
+        component="belief.main.prior",
+        model="openai/o4-mini",
+        prompt_tokens=1000,
+        completion_tokens=500,
+        agent_name="belief_agent",
+        node_id="node_2_0",
+        cost={
+            "total_usd": 0.0022,
+            "prompt_usd": 0.0011,
+            "completion_usd": 0.0004,
+            "reasoning_usd": 0.0007,
+        },
+    )
+
+    summary = tracker.get_summary()
+    expected = {
+        "calls_with_cost": 1,
+        "cost_usd": 0.0022,
+        "prompt_cost_usd": 0.0011,
+        "completion_cost_usd": 0.0004,
+        "reasoning_cost_usd": 0.0007,
+    }
+    assert _cost_fields(summary["totals"]) == expected
+    assert _cost_fields(summary["by_model"]["openai/o4-mini"]) == expected
+    assert _cost_fields(summary["by_agent"]["belief_agent"]) == expected
+    assert _cost_fields(summary["by_node"]["node_2_0"]) == expected
+    assert _cost_fields(summary["by_component"]["belief.main.prior"]) == expected
+
+
+def test_record_event_sums_costs_across_calls() -> None:
+    tracker = UsageTracker()
+    for total, prompt in ((0.25, 0.10), (0.75, 0.30)):
+        tracker.record_event(
+            source="openai",
+            component="belief.main.prior",
+            model="openai/gpt-4o",
+            prompt_tokens=10,
+            completion_tokens=2,
+            agent_name="belief_agent",
+            cost={"total_usd": total, "prompt_usd": prompt, "completion_usd": total - prompt},
+        )
+
+    totals = tracker.get_summary()["totals"]
+    assert totals["calls"] == 2
+    assert totals["calls_with_cost"] == 2
+    assert totals["cost_usd"] == 1.0
+    assert totals["prompt_cost_usd"] == pytest.approx(0.4)
+    assert totals["completion_cost_usd"] == pytest.approx(0.6)
+
+
+def test_uncosted_calls_are_counted_but_priced_at_nothing() -> None:
+    """calls_with_cost is what separates "these were free" from "nobody knows"."""
+    tracker = UsageTracker()
+    tracker.record_event(
+        source="openai",
+        component="belief.main.prior",
+        model="github_copilot/gpt-4o",
+        prompt_tokens=10,
+        completion_tokens=2,
+    )
+
+    totals = tracker.get_summary()["totals"]
+    assert totals["calls"] == 1
+    assert totals["calls_with_cost"] == 0
+    assert totals["cost_usd"] == 0.0
+    assert totals["prompt_cost_usd"] == 0.0
+    assert totals["completion_cost_usd"] == 0.0
+    assert totals["reasoning_cost_usd"] == 0.0
+    assert tracker._events[0]["cost"] is None
+
+
+def test_a_bucket_may_mix_costed_and_uncosted_calls() -> None:
+    """A partially-priced bucket reports its total as a lower bound, not a gap."""
+    tracker = UsageTracker()
+    tracker.record_event(
+        source="openai",
+        component="belief.main.prior",
+        model="openai/gpt-4o",
+        prompt_tokens=10,
+        completion_tokens=2,
+        cost={"total_usd": 0.25},
+    )
+    tracker.record_event(
+        source="openai",
+        component="belief.main.prior",
+        model="openai/gpt-4o",
+        prompt_tokens=10,
+        completion_tokens=2,
+    )
+
+    bucket = tracker.get_summary()["by_component"]["belief.main.prior"]
+    assert bucket["calls"] == 2
+    assert bucket["calls_with_cost"] == 1
+    assert bucket["cost_usd"] == 0.25
+
+
+def test_record_response_prices_the_call_when_given_the_request_model() -> None:
+    """A response reports a bare model name; pricing it needs the provider too."""
+    tracker = UsageTracker()
+    tracker.record_response(
+        _FakePricedResponse(
+            "gpt-4o", prompt_tokens=1000, completion_tokens=500, response_cost=0.0075
+        ),
+        source="openai",
+        component="belief.main.prior",
+        request_model="openai/gpt-4o",
+    )
+
+    cost = tracker._events[0]["cost"]
+    assert cost["total_usd"] == 0.0075
+    assert cost["prompt_usd"] + cost["completion_usd"] + cost["reasoning_usd"] == pytest.approx(
+        0.0075, rel=1e-9
+    )
+    totals = tracker.get_summary()["totals"]
+    assert totals["cost_usd"] == 0.0075
+    assert totals["calls_with_cost"] == 1
+
+
+def test_record_response_without_a_request_model_records_no_cost() -> None:
+    tracker = UsageTracker()
+    tracker.record_response(
+        _FakePricedResponse(
+            "gpt-4o", prompt_tokens=1000, completion_tokens=500, response_cost=0.0075
+        ),
+        source="openai",
+        component="belief.main.prior",
+    )
+
+    assert tracker._events[0]["cost"] is None
+    totals = tracker.get_summary()["totals"]
+    assert totals["calls"] == 1
+    assert totals["calls_with_cost"] == 0
+    assert totals["cost_usd"] == 0.0
+
+
+def _ag2_snapshot(cost: float | None, prompt: int, completion: int) -> dict:
+    return {
+        "experiment_generator": {
+            "total_cost": cost,
+            "gpt-4o": {
+                "cost": cost,
+                "prompt_tokens": prompt,
+                "completion_tokens": completion,
+                "total_tokens": prompt + completion,
+            },
+        }
+    }
+
+
+def test_agent_usage_deltas_carry_the_ag2_cost_delta_as_a_total() -> None:
+    """AG2 only keeps a running total, so the delta has no prompt/completion split."""
+    tracker = UsageTracker()
+    tracker.record_agent_usage_deltas(
+        _ag2_snapshot(1.0, 10, 5),
+        _ag2_snapshot(1.5, 30, 15),
+        node_id="node_3_1",
+    )
+
+    assert tracker._events[0]["cost"] == {"total_usd": 0.5}
+    totals = tracker.get_node_summary("node_3_1")["totals"]
+    assert totals["calls_with_cost"] == 1
+    assert totals["cost_usd"] == 0.5
+    assert totals["prompt_cost_usd"] == 0.0
+    assert totals["completion_cost_usd"] == 0.0
+
+
+def test_agent_usage_deltas_report_a_zero_cost_delta_as_unavailable() -> None:
+    """AG2's interface forces an unpriced model to 0.0; real tokens cost something."""
+    tracker = UsageTracker()
+    tracker.record_agent_usage_deltas(
+        _ag2_snapshot(0.0, 10, 5),
+        _ag2_snapshot(0.0, 30, 15),
+        node_id="node_3_1",
+    )
+
+    assert tracker._events[0]["cost"] is None
+    totals = tracker.get_node_summary("node_3_1")["totals"]
+    assert totals["calls"] == 1
+    assert totals["prompt_tokens"] == 20
+    assert totals["calls_with_cost"] == 0
+    assert totals["cost_usd"] == 0.0

--- a/ui/src/app/metrics/components/AggregatedUsageDialog.tsx
+++ b/ui/src/app/metrics/components/AggregatedUsageDialog.tsx
@@ -32,12 +32,26 @@ const PALETTE = [
     '#fbbf24',
 ];
 
+// Cost recorded without a prompt / completion / reasoning split.
+const SPLIT_UNAVAILABLE_COLOR = '#6b7280';
+
 const fmt = (n: number) => (n || 0).toLocaleString();
 const fmtCost = (n: number) => `$${n.toFixed(2)}`;
+
+// One recording path knows a call's total cost but not how it splits across
+// prompt / completion / reasoning, so the parts can be zero while the total isn't.
+function hasCostSplit(b: AggregatedUsageBucket): boolean {
+    const parts =
+        (b.total_prompt_cost_usd || 0) +
+        (b.total_completion_cost_usd || 0) +
+        (b.total_reasoning_cost_usd || 0);
+    return parts > 1e-9;
+}
 
 function emptyBucket(): AggregatedUsageBucket {
     return {
         total_calls: 0,
+        priced_calls: 0,
         total_prompt_tokens: 0,
         total_completion_tokens: 0,
         total_reasoning_tokens: 0,
@@ -58,6 +72,7 @@ function sumBuckets(buckets: AggregatedUsageBucket[]): AggregatedUsageBucket {
     const acc = emptyBucket();
     buckets.forEach((b) => {
         acc.total_calls += b.total_calls || 0;
+        acc.priced_calls += b.priced_calls || 0;
         acc.total_prompt_tokens += b.total_prompt_tokens || 0;
         acc.total_completion_tokens += b.total_completion_tokens || 0;
         acc.total_reasoning_tokens += b.total_reasoning_tokens || 0;
@@ -199,7 +214,14 @@ function AggregatedUsageContent({ data }: { data: AggregatedUsageResponse }) {
             l: 'Total Tokens',
             sub: `${fmt(Math.round(t.mean_tokens_per_run))} avg/run`,
         },
-        { v: String(t.total_calls), l: 'Total Calls' },
+        {
+            v: String(t.total_calls),
+            l: 'Total Calls',
+            sub:
+                t.total_calls > t.priced_calls
+                    ? `${fmt(t.total_calls - t.priced_calls)} calls unpriced`
+                    : undefined,
+        },
         {
             v: fmtCost(t.total_cost_usd),
             l: 'Total LLM Cost',
@@ -270,6 +292,15 @@ function AggregatedUsageContent({ data }: { data: AggregatedUsageResponse }) {
         beliefPriorAggregate.total_cost_usd > 0
             ? beliefPosteriorAggregate.total_cost_usd / beliefPriorAggregate.total_cost_usd
             : null;
+
+    const costSplitUnavailable = activeCostBreakdownView
+        ? Object.values(data[activeCostBreakdownView.key]).some(
+              (b) => b.total_cost_usd > 0 && !hasCostSplit(b)
+          )
+        : false;
+    const beliefSplitUnavailable = [beliefPriorAggregate, beliefPosteriorAggregate].some(
+        (b) => b.total_cost_usd > 0 && !hasCostSplit(b)
+    );
 
     return (
         <Box>
@@ -401,6 +432,12 @@ function AggregatedUsageContent({ data }: { data: AggregatedUsageResponse }) {
                         <LegendItem>
                             <LegendDot style={{ background: '#2dd4bf' }} /> Reasoning
                         </LegendItem>
+                        {costSplitUnavailable && (
+                            <LegendItem>
+                                <LegendDot style={{ background: SPLIT_UNAVAILABLE_COLOR }} /> Split
+                                unavailable
+                            </LegendItem>
+                        )}
                     </LegendRow>
                     <Tabs
                         value={costViewIndex}
@@ -460,6 +497,12 @@ function AggregatedUsageContent({ data }: { data: AggregatedUsageResponse }) {
                         <LegendItem>
                             <LegendDot style={{ background: '#2dd4bf' }} /> Reasoning
                         </LegendItem>
+                        {beliefSplitUnavailable && (
+                            <LegendItem>
+                                <LegendDot style={{ background: SPLIT_UNAVAILABLE_COLOR }} /> Split
+                                unavailable
+                            </LegendItem>
+                        )}
                     </LegendRow>
                     <BeliefPriorPosteriorBars
                         prior={beliefPriorAggregate}
@@ -509,11 +552,22 @@ function BeliefPriorPosteriorBars({
                 const completionPct = total > 0 ? (b.total_completion_cost_usd / total) * 100 : 0;
                 const reasoningPct = total > 0 ? (b.total_reasoning_cost_usd / total) * 100 : 0;
                 const small = widthPct < 20;
+                const splitKnown = hasCostSplit(b);
                 return (
                     <BarRow key={stage}>
                         <BarLabel>{stage === 'prior' ? 'Prior' : 'Posterior'}</BarLabel>
                         <BarTrack>
                             <CostBarFill style={{ width: `${Math.max(widthPct, 1.5)}%` }}>
+                                {/* Without a split the parts are all zero, so fill the bar with a
+                                    single neutral segment rather than leaving it empty. */}
+                                {!splitKnown && (
+                                    <CostSegment
+                                        style={{
+                                            width: '100%',
+                                            background: SPLIT_UNAVAILABLE_COLOR,
+                                        }}
+                                    />
+                                )}
                                 {promptPct > 0 && (
                                     <CostSegment
                                         style={{ width: `${promptPct}%`, background: '#818cf8' }}
@@ -668,12 +722,23 @@ function CostBreakdownBars({ data }: { data: Record<string, AggregatedUsageBucke
                 const completionPct = total > 0 ? (d.total_completion_cost_usd / total) * 100 : 0;
                 const reasoningPct = total > 0 ? (d.total_reasoning_cost_usd / total) * 100 : 0;
                 const small = widthPct < 20;
+                const splitKnown = hasCostSplit(d);
 
                 return (
                     <BarRow key={key}>
                         <BarLabel>{prettyName(key)}</BarLabel>
                         <BarTrack>
                             <CostBarFill style={{ width: `${Math.max(widthPct, 1.5)}%` }}>
+                                {/* Without a split the parts are all zero, so fill the bar with a
+                                    single neutral segment rather than leaving it empty. */}
+                                {!splitKnown && (
+                                    <CostSegment
+                                        style={{
+                                            width: '100%',
+                                            background: SPLIT_UNAVAILABLE_COLOR,
+                                        }}
+                                    />
+                                )}
                                 {promptPct > 0 && (
                                     <CostSegment
                                         style={{ width: `${promptPct}%`, background: '#818cf8' }}

--- a/ui/src/app/metrics/components/MetricCard.tsx
+++ b/ui/src/app/metrics/components/MetricCard.tsx
@@ -6,11 +6,12 @@ interface MetricCardProps {
     value: string | number;
     label: string;
     subValue?: string;
+    title?: string;
 }
 
-export default function MetricCard({ value, label, subValue }: MetricCardProps) {
+export default function MetricCard({ value, label, subValue, title }: MetricCardProps) {
     return (
-        <Card>
+        <Card title={title}>
             <Value>{value}</Value>
             <Label>{label}</Label>
             {subValue && <SubValue>{subValue}</SubValue>}

--- a/ui/src/app/metrics/components/UsersTable.tsx
+++ b/ui/src/app/metrics/components/UsersTable.tsx
@@ -9,6 +9,9 @@ import { scrollbarStyles } from '@/utils/scrollbar';
 
 type SortKey = keyof UserMetricsSummary;
 
+const missingCostTitle = (n: number) =>
+    `Excludes ${n} run${n === 1 ? '' : 's'} with no recorded cost`;
+
 interface UsersTableProps {
     users: UserMetricsSummary[];
 }
@@ -87,9 +90,18 @@ export default function UsersTable({ users }: UsersTableProps) {
                             {columns.map((col) => {
                                 const raw = user[col.key];
                                 const formatted = col.format ? col.format(raw) : String(raw ?? '-');
+                                // The cost only covers runs that recorded one, so flag the rest.
+                                const costCaveat =
+                                    col.key === 'llm_cost_usd' && user.runs_missing_cost > 0
+                                        ? missingCostTitle(user.runs_missing_cost)
+                                        : undefined;
                                 return (
-                                    <Td key={col.key} $align={col.align || 'right'}>
+                                    <Td
+                                        key={col.key}
+                                        $align={col.align || 'right'}
+                                        title={costCaveat}>
                                         {formatted}
+                                        {costCaveat && <CaveatMark>*</CaveatMark>}
                                     </Td>
                                 );
                             })}
@@ -153,6 +165,11 @@ const Td = styled('td')<{ $align?: string }>`
     border-bottom: 1px solid
         ${({ theme }) => theme.color['cream-4']?.rgba?.toString() || 'rgba(255,255,255,0.04)'};
     color: ${({ theme }) => theme.color['cream-80']?.rgba?.toString() || 'rgba(255,255,255,0.8)'};
+`;
+
+const CaveatMark = styled('span')`
+    margin-left: 3px;
+    color: ${({ theme }) => theme.color['cream-40']?.rgba?.toString() || 'rgba(255,255,255,0.4)'};
 `;
 
 const ClickableRow = styled('tr')`

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -14,6 +14,9 @@ import DailyEnvelopeCharts from './components/DailyEnvelopeCharts';
 
 const WARMING_UP_POLL_MS = 5000;
 
+const missingCostNote = (n: number) =>
+    n > 0 ? `excludes ${n} run${n === 1 ? '' : 's'} with no recorded cost` : undefined;
+
 export default function MetricsOverviewPage() {
     const [data, setData] = useState<OverviewMetrics | null>(null);
     const [loading, setLoading] = useState(true);
@@ -162,7 +165,11 @@ export default function MetricsOverviewPage() {
                     </Button>
                 </SubsectionHeader>
                 <CardGrid>
-                    <MetricCard value={fmtCost(data.llm_cost_usd)} label="Total LLM Cost" />
+                    <MetricCard
+                        value={fmtCost(data.llm_cost_usd)}
+                        label="Total LLM Cost"
+                        subValue={missingCostNote(data.runs_missing_cost)}
+                    />
                     <MetricCard
                         value={
                             data.cost_per_hypothesis_usd != null

--- a/ui/src/app/metrics/runs/[userid]/[runid]/page.tsx
+++ b/ui/src/app/metrics/runs/[userid]/[runid]/page.tsx
@@ -6,7 +6,7 @@ import { useParams, useRouter } from 'next/navigation';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 import { getMetricsApi } from '@/api/MetricsApi';
-import type { RunMetrics } from '@/types/Metrics';
+import type { LLMCostStatus, RunMetrics } from '@/types/Metrics';
 import MetricCard from '../../../components/MetricCard';
 import LLMUsageDashboard from '../../../components/LLMUsageDashboard';
 
@@ -18,6 +18,12 @@ const STATUS_COLORS: Record<string, string> = {
     PENDING: 'info',
     CREATED: 'default',
     DELETED: 'default',
+};
+
+const COST_STATUS_TITLES: Record<LLMCostStatus, string | undefined> = {
+    complete: undefined,
+    partial: 'Some calls could not be priced',
+    unavailable: 'No per-call cost recorded for this run',
 };
 
 export default function RunMetricsPage() {
@@ -63,6 +69,11 @@ export default function RunMetricsPage() {
     }
 
     const fmtCost = (v: number) => `$${v.toFixed(2)}`;
+    const fmtCostStatus = (v: number, status: LLMCostStatus) => {
+        if (status === 'unavailable') return 'n/a';
+        if (status === 'partial') return `≥ ${fmtCost(v)}`;
+        return fmtCost(v);
+    };
     const fmtDuration = (secs: number | null) => {
         if (secs == null) return '-';
         if (secs < 60) return `${secs.toFixed(0)}s`;
@@ -115,7 +126,11 @@ export default function RunMetricsPage() {
 
             {/* Cost & Experiment Cards */}
             <CardGrid>
-                <MetricCard value={fmtCost(data.llm_cost_usd)} label="LLM Cost" />
+                <MetricCard
+                    value={fmtCostStatus(data.llm_cost_usd, data.llm_cost_status)}
+                    label="LLM Cost"
+                    title={COST_STATUS_TITLES[data.llm_cost_status]}
+                />
                 <MetricCard
                     value={`${data.n_experiments_completed}/${data.n_experiments_requested}`}
                     label="Experiments"
@@ -123,21 +138,25 @@ export default function RunMetricsPage() {
             </CardGrid>
 
             {/* LLM Cost by Model */}
-            {data.llm_cost_by_model && Object.keys(data.llm_cost_by_model).length > 0 && (
-                <Panel>
-                    <PanelTitle>Cost by Model</PanelTitle>
-                    <CostList>
-                        {Object.entries(data.llm_cost_by_model)
-                            .sort((a, b) => b[1] - a[1])
-                            .map(([model, cost]) => (
-                                <CostRow key={model}>
-                                    <CostModel>{model}</CostModel>
-                                    <CostValue>{fmtCost(cost)}</CostValue>
-                                </CostRow>
-                            ))}
-                    </CostList>
-                </Panel>
-            )}
+            {data.llm_cost_status !== 'unavailable' &&
+                data.llm_cost_by_model &&
+                Object.keys(data.llm_cost_by_model).length > 0 && (
+                    <Panel>
+                        <PanelTitle>Cost by Model</PanelTitle>
+                        <CostList>
+                            {Object.entries(data.llm_cost_by_model)
+                                .sort((a, b) => b[1] - a[1])
+                                .map(([model, cost]) => (
+                                    <CostRow key={model}>
+                                        <CostModel>{model}</CostModel>
+                                        <CostValue title={COST_STATUS_TITLES[data.llm_cost_status]}>
+                                            {fmtCostStatus(cost, data.llm_cost_status)}
+                                        </CostValue>
+                                    </CostRow>
+                                ))}
+                        </CostList>
+                    </Panel>
+                )}
 
             {/* Full LLM Usage Dashboard */}
             {data.llm_usage_summary && (
@@ -147,7 +166,11 @@ export default function RunMetricsPage() {
                     </Typography>
                     <LLMUsageDashboard
                         usage={data.llm_usage_summary}
-                        costByModel={data.llm_cost_by_model}
+                        costByModel={
+                            data.llm_cost_status === 'unavailable'
+                                ? undefined
+                                : data.llm_cost_by_model
+                        }
                     />
                 </Box>
             )}

--- a/ui/src/app/metrics/users/[userid]/page.tsx
+++ b/ui/src/app/metrics/users/[userid]/page.tsx
@@ -6,7 +6,7 @@ import { useParams, useRouter } from 'next/navigation';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 import { getMetricsApi } from '@/api/MetricsApi';
-import type { UserDetailMetrics } from '@/types/Metrics';
+import type { LLMCostStatus, UserDetailMetrics } from '@/types/Metrics';
 import MetricCard from '../../components/MetricCard';
 import { scrollbarStyles } from '@/utils/scrollbar';
 
@@ -19,6 +19,15 @@ const STATUS_COLORS: Record<string, string> = {
     CREATED: 'default',
     DELETED: 'default',
 };
+
+const COST_STATUS_TITLES: Record<LLMCostStatus, string | undefined> = {
+    complete: undefined,
+    partial: 'Some calls could not be priced',
+    unavailable: 'No per-call cost recorded for this run',
+};
+
+const missingCostNote = (n: number) =>
+    n > 0 ? `excludes ${n} run${n === 1 ? '' : 's'} with no recorded cost` : undefined;
 
 export default function UserDetailPage() {
     const params = useParams();
@@ -63,6 +72,11 @@ export default function UserDetailPage() {
 
     const s = data.summary;
     const fmtCost = (v: number) => `$${v.toFixed(2)}`;
+    const fmtCostStatus = (v: number, status: LLMCostStatus) => {
+        if (status === 'unavailable') return 'n/a';
+        if (status === 'partial') return `≥ ${fmtCost(v)}`;
+        return fmtCost(v);
+    };
     const fmtPct = (v: number) => `${(v * 100).toFixed(1)}%`;
     const fmtDuration = (secs: number | null) => {
         if (secs == null) return '-';
@@ -102,7 +116,11 @@ export default function UserDetailPage() {
                 <MetricCard value={s.total_runs.toLocaleString()} label="Total Runs" />
                 <MetricCard value={fmtPct(s.success_rate)} label="Success Rate" />
                 <MetricCard value={s.total_experiments.toLocaleString()} label="Experiments" />
-                <MetricCard value={fmtCost(s.llm_cost_usd)} label="LLM Cost" />
+                <MetricCard
+                    value={fmtCost(s.llm_cost_usd)}
+                    label="LLM Cost"
+                    subValue={missingCostNote(s.runs_missing_cost)}
+                />
                 <MetricCard value={s.shared_runs.toLocaleString()} label="Shared Runs" />
             </CardGrid>
 
@@ -146,7 +164,9 @@ export default function UserDetailPage() {
                                     {run.n_experiments_completed}/{run.n_experiments_requested}
                                 </Td>
                                 <Td>{fmtDuration(run.duration_seconds)}</Td>
-                                <Td>{fmtCost(run.llm_cost_usd)}</Td>
+                                <Td title={COST_STATUS_TITLES[run.llm_cost_status]}>
+                                    {fmtCostStatus(run.llm_cost_usd, run.llm_cost_status)}
+                                </Td>
                                 <Td>
                                     {run.created_at
                                         ? new Date(run.created_at).toLocaleDateString()

--- a/ui/src/app/types/Metrics.ts
+++ b/ui/src/app/types/Metrics.ts
@@ -2,6 +2,13 @@
  * TypeScript types for the metrics dashboard API responses.
  */
 
+/**
+ * Whether every recorded LLM call for a run carried a cost. Runs from before
+ * per-call cost recording, and providers litellm cannot price per token, have
+ * no dollar figure at all.
+ */
+export type LLMCostStatus = 'complete' | 'partial' | 'unavailable';
+
 export interface DailyMetrics {
     date: string;
     runs_started: number;
@@ -23,6 +30,7 @@ export interface OverviewMetrics {
     total_experiments_requested: number;
     experiment_completion_rate: number;
     llm_cost_usd: number;
+    runs_missing_cost: number;
     hypotheses_with_usage: number;
     cost_per_hypothesis_usd: number | null;
     share_rate: number;
@@ -40,6 +48,7 @@ export interface UserMetricsSummary {
     success_rate: number;
     total_experiments: number;
     llm_cost_usd: number;
+    runs_missing_cost: number;
     shared_runs: number;
     last_activity: string | null;
 }
@@ -58,6 +67,7 @@ export interface RunSummary {
     is_shared: boolean;
     model: string | null;
     llm_cost_usd: number;
+    llm_cost_status: LLMCostStatus;
 }
 
 export interface UserDetailMetrics {
@@ -93,6 +103,7 @@ export interface RunMetrics {
     duration_seconds: number | null;
     llm_usage_summary: LLMUsageSummary | null;
     llm_cost_usd: number;
+    llm_cost_status: LLMCostStatus;
     llm_cost_by_model: Record<string, number>;
     n_experiments_requested: number;
     n_experiments_completed: number;
@@ -107,6 +118,7 @@ export interface UsersListResponse {
 
 export interface AggregatedUsageBucket {
     total_calls: number;
+    priced_calls: number;
     total_prompt_tokens: number;
     total_completion_tokens: number;
     total_reasoning_tokens: number;


### PR DESCRIPTION
Closes #70.

`api/metrics/costs.py` carried a 16-entry price table, a provider-prefix stripper and a Gemini-3.1-Pro fallback rate. litellm is already the transport for every model call and already computes each call's cost from its own maintained prices — we were discarding that and approximating it later from a stale snapshot. This records it at the source instead, and the dashboard now sums a field.

## What changed

**Producer** (`packages/autodiscovery`)

- `llm.reported_cost(response)` — the single reader of `_hidden_params["response_cost"]`.
- `llm.cost_of(response, model)` — returns `{total_usd, prompt_usd, completion_usd, reasoning_usd}`. `response_cost` is the authoritative total and is never recomputed; the split comes from `litellm.cost_per_token` and is *scaled onto* that total, because `response_cost` also covers cache reads, image input and built-in tools that a plain prompt/completion split does not.
- `UsageTracker.record_event(..., cost=)` stores it per event; `record_response(..., request_model=)` prices the call. Pricing needs the provider and a response only reports a bare model name, hence the extra argument — wired through all five call sites including the sandbox image-analysis path, which prices in-sandbox and carries the result out through its usage marker.
- `_empty_bucket()` gains `cost_usd`, `prompt_cost_usd`, `completion_cost_usd`, `reasoning_cost_usd` and `calls_with_cost`, so cost aggregates into `by_model` / `by_agent` / `by_node` / `by_component` alongside the token counts.

**Consumer** (`api/`)

- `LLM_PRICING`, `_FALLBACK_PRICING`, `_lookup_pricing` and `_lookup_bucket_cost_by_type` are gone. `calculate_llm_cost` keeps its signature and return type. The `aggregator.py:191` call site you flagged (`_lookup_pricing` imported directly) went with it — `_build_event_cost_breakdowns` now sums recorded event costs rather than pricing each bucket.
- litellm is **not** added to `api/requirements.txt`.

## The three questions the issue left open

**Backwards compatibility → report unavailable.** As you suggested. Pre-change runs have no cost field, so `cost_status()` reads `unavailable` and the dashboard shows a dash with a tooltip instead of a dollar figure; aggregate cards carry a quiet `excludes N runs with no recorded cost` caveat. No legacy pricing path is kept.

**Does litellm have cost data for `github_copilot/*`? No.** All 33 of its `github_copilot` registry entries carry a null input and output cost — consistent with Copilot billing premium requests rather than tokens. litellm surfaces that as a *zero* price, not an absent one, so a naive "use `response_cost`" would have reported every Copilot run at exactly $0.00 — a different wrong answer than before, and a harder one to notice. `cost_of` therefore treats a zero cost over a non-empty prompt as unpriced and returns `None`. That distinction is the reason for `calls_with_cost` rather than a plain cost field: it is what separates "this call was free" from "nobody knows what this call cost".

**`total - prompt` output-token arithmetic → gone**, as you expected. Reasoning tokens are a subset of `completion_tokens` in the usage shape litellm normalizes to, so `reasoning_usd` is now carved *out of* the completion cost. The old dashboard code added them (`explicit_output_tokens = completion_tokens + reasoning_tokens`), which double-counted.

## Cost status, three states

`llm_cost_status` is `complete` (every call priced), `partial` (some priced — total renders as `≥ $x.yz`) or `unavailable`. `partial` is reachable in one run: a mixed-provider run after #68, where the Vertex calls price and the Copilot ones do not.

`AggregatedUsageBucket` gains `priced_calls` alongside `total_calls`. One recording path — AG2's `summary_delta` mode — knows a call's total but not its split, so the stacked cost bars fall back to a single neutral segment rather than rendering as empty.

## Not done here

`by_model` is still keyed by the bare model name the response reports, so `openai/gpt-4o` and `github_copilot/gpt-4o` still share a row in that one breakdown. Cost is unaffected — it is summed per call, not priced per label — so this is now cosmetic rather than a mispricing. Qualifying the key would split every existing model row in two across the old/new boundary, which seemed worth doing deliberately rather than as a side effect of this change.

## Testing

30 new tests (`test_llm_cost.py`, `test_llm_usage.py`, `api/tests/test_costs.py`, `api/tests/test_aggregator_costs.py`) covering: Copilot and unmapped models pricing to `None`; the split summing to the injected `response_cost` including when the two disagree; reasoning carved out of completion; and a pre-change usage summary reading as `unavailable`. `make test` is 218 passed, 1 failed — the failure is `test_ipython_session.py::test_run_cell_subprocess_success`, which cannot write `$HOME/.cache/matplotlib` in this sandbox and touches no cost code. `tsc --noEmit` and `eslint` are clean on the UI; `next build` was OOM-killed in the sandbox, so a full UI build is unverified here and CI should be watched.

Suggested-by: @dirkraft
