### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the published packages — [`asta-autodiscovery`][pypi]
 
 [pypi]: https://pypi.org/project/asta-autodiscovery/
 
-## Unreleased
+## 1.0.1
 
 ### Breaking: Vertex AI is configured with litellm's own variables ([#78])
 

--- a/packages/agents/pyproject.toml
+++ b/packages/agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-agents"
-version = "1.0.0"
+version = "1.0.1"
 description = "Add your description here"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/autodiscovery/pyproject.toml
+++ b/packages/autodiscovery/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-autodiscovery"
-version = "1.0.0"
+version = "1.0.1"
 description = "Open-ended Scientific Discovery via Bayesian Surprise"
 readme = "RELEASE.md"
 license = "Apache-2.0"

--- a/packages/autodiscovery_jobs/pyproject.toml
+++ b/packages/autodiscovery_jobs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-autodiscovery-jobs"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python package for managing Cloud Run jobs with GCS integration"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/autodiscovery_jobs/src/autodiscovery_jobs/__init__.py
+++ b/packages/autodiscovery_jobs/src/autodiscovery_jobs/__init__.py
@@ -104,7 +104,7 @@ from .user_profile import (
     update_user_profile,
 )
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 __all__ = [
     # Main class

--- a/packages/autodiscovery_modal/pyproject.toml
+++ b/packages/autodiscovery_modal/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-autodiscovery-modal"
-version = "1.0.0"
+version = "1.0.1"
 description = "Add your description here"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/code_execution/pyproject.toml
+++ b/packages/code_execution/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-code-execution"
-version = "1.0.0"
+version = "1.0.1"
 description = "Add your description here"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/devtools/pyproject.toml
+++ b/packages/devtools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-devtools"
-version = "1.0.0"
+version = "1.0.1"
 description = "Developer tooling for AutoDiscovery"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asta-autodiscovery-workspace"
-version = "1.0.0"
+version = "1.0.1"
 description = "Asta AutoDiscovery (workspace root)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "asta-agents"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "packages/agents" }
 dependencies = [
     { name = "asta-autodiscovery-modal" },
@@ -203,7 +203,7 @@ requires-dist = [
 
 [[package]]
 name = "asta-autodiscovery"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "packages/autodiscovery" }
 dependencies = [
     { name = "ag2" },
@@ -246,7 +246,7 @@ requires-dist = [
 
 [[package]]
 name = "asta-autodiscovery-jobs"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "packages/autodiscovery_jobs" }
 dependencies = [
     { name = "docker" },
@@ -278,7 +278,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "asta-autodiscovery-modal"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "packages/autodiscovery_modal" }
 dependencies = [
     { name = "asta-sandbox", extra = ["modal-ephemeral"] },
@@ -293,7 +293,7 @@ requires-dist = [
 
 [[package]]
 name = "asta-autodiscovery-workspace"
-version = "1.0.0"
+version = "1.0.1"
 source = { virtual = "." }
 
 [package.optional-dependencies]
@@ -337,7 +337,7 @@ dev = [
 
 [[package]]
 name = "asta-code-execution"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "packages/code_execution" }
 dependencies = [
     { name = "ipython" },
@@ -348,7 +348,7 @@ requires-dist = [{ name = "ipython", specifier = ">=9.9.0" }]
 
 [[package]]
 name = "asta-devtools"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "packages/devtools" }
 dependencies = [
     { name = "google-cloud-storage" },


### PR DESCRIPTION
Bumps all workspace packages from 1.0.0 to 1.0.1 via `make set-version` and closes out the `Unreleased` changelog section, which holds the Vertex configuration change from #83.

After merge: push the `v1.0.1` tag from `main` (`make push-version-tag`) and run the *Publish to PyPI* workflow with `v1.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)