### PR TITLE
Cap code-executor output so a printed dataset can't OOM the job

### DIFF
--- a/packages/autodiscovery/src/autodiscovery/agents.py
+++ b/packages/autodiscovery/src/autodiscovery/agents.py
@@ -40,28 +40,39 @@ IMAGE_ANALYST_PROMPT = """Please analyze the given plot image and provide the fo
 # becomes a chat message that is then re-serialized into every subsequent LLM
 # request — so an uncapped output is copied many times over and OOM-kills the job.
 # Observed in production: a single block emitted 676 MB of stdout and the container
-# was SIGKILLed (exit 137) on the next turn.
-DEFAULT_MAX_CODE_OUTPUT_CHARS = 200_000
+# was SIGKILLed (exit 137) on the next turn. 20k characters is roughly 5k LLM
+# tokens: enough for about 10k characters from each end (including a typical
+# traceback or many tabular rows) without letting one tool result consume a large
+# fraction of a future model request.
+MAX_CODE_OUTPUT_CHARS = 20_000
 
 
-def _truncate_output(output: str, max_chars: int) -> str:
-    """Clip an over-long code output to ``max_chars``, keeping both ends.
+def _truncate_output(output: str) -> str:
+    """Clip an over-long code output to the fixed cap, keeping both ends.
 
     The head carries whatever the code printed first (headers, schema, counts) and
     the tail carries the final result, so both are worth keeping; only the middle
-    is dropped. A non-positive ``max_chars`` disables truncation.
+    is dropped. The truncation notice itself counts toward the cap.
     """
-    if max_chars <= 0 or len(output) <= max_chars:
+    if len(output) <= MAX_CODE_OUTPUT_CHARS:
         return output
 
-    dropped = len(output) - max_chars
-    notice = (
-        f"\n\n... [output truncated: {dropped} of {len(output)} characters omitted; "
-        f"limit is {max_chars}. Do not print whole datasets — aggregate, sample, or "
-        f"write to a file and read back only what you need.] ...\n\n"
-    )
-    head = max_chars // 2
-    tail = max_chars - head
+    dropped = len(output) - MAX_CODE_OUTPUT_CHARS
+    while True:
+        notice = (
+            f"\n\n... [output truncated: {dropped} of {len(output)} characters omitted; "
+            f"limit is {MAX_CODE_OUTPUT_CHARS}. Do not print whole datasets — "
+            f"aggregate, sample, or write to a file and read back only what you "
+            f"need.] ...\n\n"
+        )
+        retained = MAX_CODE_OUTPUT_CHARS - len(notice)
+        actual_dropped = len(output) - retained
+        if actual_dropped == dropped:
+            break
+        dropped = actual_dropped
+
+    head = retained // 2
+    tail = retained - head
     return output[:head] + notice + output[-tail:]
 
 
@@ -121,7 +132,6 @@ class ModalSandboxExecutor(CodeExecutor):
         vision_model: str,
         timeout: int = 30 * 60,
         usage_tracker: UsageTracker | None = None,
-        max_output_chars: int | None = None,
     ):
         """Initialize the sandbox executor wrapper.
 
@@ -130,19 +140,9 @@ class ModalSandboxExecutor(CodeExecutor):
             timeout: Timeout in seconds (for Autogen compatibility)
             vision_model: Vision model, as litellm's ``<provider>/<model>``
             usage_tracker: Optional usage tracker for image analysis calls.
-            max_output_chars: Cap on the output handed back to the chat, overriding
-                ``AUTODISCOVERY_MAX_CODE_OUTPUT_CHARS`` and
-                ``DEFAULT_MAX_CODE_OUTPUT_CHARS``. Non-positive disables the cap.
         """
         self._executor = backend
         self._timeout = timeout
-        if max_output_chars is None:
-            max_output_chars = int(
-                os.environ.get(
-                    "AUTODISCOVERY_MAX_CODE_OUTPUT_CHARS", DEFAULT_MAX_CODE_OUTPUT_CHARS
-                )
-            )
-        self._max_output_chars = max_output_chars
         self.vision_model = vision_model
         self._usage_tracker = usage_tracker
         self._usage_node_id: str | None = None
@@ -215,13 +215,13 @@ class ModalSandboxExecutor(CodeExecutor):
 
             print(f"[CodeExecutor] Stdout length: {len(output)} characters")
 
-            output = _truncate_output(output, self._max_output_chars)
+            output = _truncate_output(output)
             if len(output) != len(result.stdout or ""):
                 print(f"[CodeExecutor] Stdout truncated to {len(output)} characters")
 
             if result.stderr:
                 print(f"[CodeExecutor] Stderr: {result.stderr[:200]}")
-                stderr = _truncate_output(result.stderr, self._max_output_chars)
+                stderr = _truncate_output(result.stderr)
                 output += f"\nSTDERR:\n{stderr}"
 
             if not result.success:
@@ -237,7 +237,7 @@ class ModalSandboxExecutor(CodeExecutor):
                     error_msg = f"Execution timed out after {self._timeout}s"
                 else:
                     error_msg = "Unknown error"
-                error_msg = _truncate_output(error_msg, self._max_output_chars)
+                error_msg = _truncate_output(error_msg)
                 print(f"[CodeExecutor] Error: {error_msg}")
                 output += f"\nERROR: {error_msg}"
 
@@ -269,6 +269,7 @@ class ModalSandboxExecutor(CodeExecutor):
                 if image_analyses:
                     output += "\n" + "\n".join(image_analyses)
 
+            output = _truncate_output(output)
             return CodeResult(exit_code=0 if result.success else 1, output=output)
 
         except Exception as e:
@@ -277,9 +278,8 @@ class ModalSandboxExecutor(CodeExecutor):
             error_details = traceback.format_exc()
             print(f"[CodeExecutor] Exception occurred: {str(e)}")
             print(f"[CodeExecutor] Traceback:\n{error_details}")
-            return CodeResult(
-                exit_code=1, output=f"Execution failed: {str(e)}\n\nTraceback:\n{error_details}"
-            )
+            output = f"Execution failed: {str(e)}\n\nTraceback:\n{error_details}"
+            return CodeResult(exit_code=1, output=_truncate_output(output))
 
     def get_last_rich_outputs(self):
         """Get rich outputs from the last execution."""

--- a/packages/autodiscovery/src/autodiscovery/agents.py
+++ b/packages/autodiscovery/src/autodiscovery/agents.py
@@ -67,11 +67,17 @@ def _truncate_output_parts(parts: list[str]) -> str:
             f"aggregate, sample, or write to a file and read back only what you "
             f"need.] ...\n\n"
         )
-        retained = MAX_CODE_OUTPUT_CHARS - len(notice)
+        retained = max(0, MAX_CODE_OUTPUT_CHARS - len(notice))
         actual_dropped = output_length - retained
         if actual_dropped == dropped:
             break
         dropped = actual_dropped
+
+    # The cap is intentionally fixed well above the notice length, but preserve
+    # the size invariant if a future edit lowers it: no Python ``[-0:]`` slice
+    # should accidentally retain an entire output section.
+    if retained == 0:
+        return notice[: max(0, MAX_CODE_OUTPUT_CHARS)]
 
     head = retained // 2
     tail = retained - head

--- a/packages/autodiscovery/src/autodiscovery/agents.py
+++ b/packages/autodiscovery/src/autodiscovery/agents.py
@@ -241,7 +241,7 @@ class ModalSandboxExecutor(CodeExecutor):
 
             if result.stderr:
                 print(f"[CodeExecutor] Stderr: {result.stderr[:200]}")
-                output_parts.append(f"\nSTDERR:\n{result.stderr}")
+                output_parts.extend(("\nSTDERR:\n", result.stderr))
 
             if not result.success:
                 if result.error:

--- a/packages/autodiscovery/src/autodiscovery/agents.py
+++ b/packages/autodiscovery/src/autodiscovery/agents.py
@@ -35,6 +35,35 @@ IMAGE_ANALYST_PROMPT = """Please analyze the given plot image and provide the fo
 4. Annotations and Legends: Describe key annotations or legends.
 5. Statistical Insights: Provide insights based on the information presented in the plot."""
 
+# Cap on how much of a code block's output is kept. Generated code regularly prints
+# an entire dataset (a raw .sql dump, a full dataframe), and the executor's output
+# becomes a chat message that is then re-serialized into every subsequent LLM
+# request — so an uncapped output is copied many times over and OOM-kills the job.
+# Observed in production: a single block emitted 676 MB of stdout and the container
+# was SIGKILLed (exit 137) on the next turn.
+DEFAULT_MAX_CODE_OUTPUT_CHARS = 200_000
+
+
+def _truncate_output(output: str, max_chars: int) -> str:
+    """Clip an over-long code output to ``max_chars``, keeping both ends.
+
+    The head carries whatever the code printed first (headers, schema, counts) and
+    the tail carries the final result, so both are worth keeping; only the middle
+    is dropped. A non-positive ``max_chars`` disables truncation.
+    """
+    if max_chars <= 0 or len(output) <= max_chars:
+        return output
+
+    dropped = len(output) - max_chars
+    notice = (
+        f"\n\n... [output truncated: {dropped} of {len(output)} characters omitted; "
+        f"limit is {max_chars}. Do not print whole datasets — aggregate, sample, or "
+        f"write to a file and read back only what you need.] ...\n\n"
+    )
+    head = max_chars // 2
+    tail = max_chars - head
+    return output[:head] + notice + output[-tail:]
+
 
 def _run_async(coro):
     """Run a coroutine from a synchronous context.
@@ -92,6 +121,7 @@ class ModalSandboxExecutor(CodeExecutor):
         vision_model: str,
         timeout: int = 30 * 60,
         usage_tracker: UsageTracker | None = None,
+        max_output_chars: int | None = None,
     ):
         """Initialize the sandbox executor wrapper.
 
@@ -100,9 +130,19 @@ class ModalSandboxExecutor(CodeExecutor):
             timeout: Timeout in seconds (for Autogen compatibility)
             vision_model: Vision model, as litellm's ``<provider>/<model>``
             usage_tracker: Optional usage tracker for image analysis calls.
+            max_output_chars: Cap on the output handed back to the chat, overriding
+                ``AUTODISCOVERY_MAX_CODE_OUTPUT_CHARS`` and
+                ``DEFAULT_MAX_CODE_OUTPUT_CHARS``. Non-positive disables the cap.
         """
         self._executor = backend
         self._timeout = timeout
+        if max_output_chars is None:
+            max_output_chars = int(
+                os.environ.get(
+                    "AUTODISCOVERY_MAX_CODE_OUTPUT_CHARS", DEFAULT_MAX_CODE_OUTPUT_CHARS
+                )
+            )
+        self._max_output_chars = max_output_chars
         self.vision_model = vision_model
         self._usage_tracker = usage_tracker
         self._usage_node_id: str | None = None
@@ -175,9 +215,14 @@ class ModalSandboxExecutor(CodeExecutor):
 
             print(f"[CodeExecutor] Stdout length: {len(output)} characters")
 
+            output = _truncate_output(output, self._max_output_chars)
+            if len(output) != len(result.stdout or ""):
+                print(f"[CodeExecutor] Stdout truncated to {len(output)} characters")
+
             if result.stderr:
                 print(f"[CodeExecutor] Stderr: {result.stderr[:200]}")
-                output += f"\nSTDERR:\n{result.stderr}"
+                stderr = _truncate_output(result.stderr, self._max_output_chars)
+                output += f"\nSTDERR:\n{stderr}"
 
             if not result.success:
                 if result.error:
@@ -192,6 +237,7 @@ class ModalSandboxExecutor(CodeExecutor):
                     error_msg = f"Execution timed out after {self._timeout}s"
                 else:
                     error_msg = "Unknown error"
+                error_msg = _truncate_output(error_msg, self._max_output_chars)
                 print(f"[CodeExecutor] Error: {error_msg}")
                 output += f"\nERROR: {error_msg}"
 

--- a/packages/autodiscovery/src/autodiscovery/agents.py
+++ b/packages/autodiscovery/src/autodiscovery/agents.py
@@ -47,33 +47,57 @@ IMAGE_ANALYST_PROMPT = """Please analyze the given plot image and provide the fo
 MAX_CODE_OUTPUT_CHARS = 20_000
 
 
-def _truncate_output(output: str) -> str:
-    """Clip an over-long code output to the fixed cap, keeping both ends.
+def _truncate_output_parts(parts: list[str]) -> str:
+    """Assemble and clip code-output sections to the fixed cap, keeping both ends.
 
     The head carries whatever the code printed first (headers, schema, counts) and
     the tail carries the final result, so both are worth keeping; only the middle
-    is dropped. The truncation notice itself counts toward the cap.
+    is dropped. The truncation notice itself counts toward the cap. Working from
+    sections avoids first concatenating potentially enormous stdout and stderr.
     """
-    if len(output) <= MAX_CODE_OUTPUT_CHARS:
-        return output
+    output_length = sum(len(part) for part in parts)
+    if output_length <= MAX_CODE_OUTPUT_CHARS:
+        return "".join(parts)
 
-    dropped = len(output) - MAX_CODE_OUTPUT_CHARS
+    dropped = output_length - MAX_CODE_OUTPUT_CHARS
     while True:
         notice = (
-            f"\n\n... [output truncated: {dropped} of {len(output)} characters omitted; "
+            f"\n\n... [output truncated: {dropped} of {output_length} characters omitted; "
             f"limit is {MAX_CODE_OUTPUT_CHARS}. Do not print whole datasets — "
             f"aggregate, sample, or write to a file and read back only what you "
             f"need.] ...\n\n"
         )
         retained = MAX_CODE_OUTPUT_CHARS - len(notice)
-        actual_dropped = len(output) - retained
+        actual_dropped = output_length - retained
         if actual_dropped == dropped:
             break
         dropped = actual_dropped
 
     head = retained // 2
     tail = retained - head
-    return output[:head] + notice + output[-tail:]
+    prefix_parts = []
+    prefix_remaining = head
+    for part in parts:
+        prefix_parts.append(part[:prefix_remaining])
+        prefix_remaining -= min(len(part), prefix_remaining)
+        if prefix_remaining == 0:
+            break
+    prefix = "".join(prefix_parts)
+
+    suffix_parts = []
+    suffix_remaining = tail
+    for part in reversed(parts):
+        suffix_parts.append(part[-suffix_remaining:])
+        suffix_remaining -= min(len(part), suffix_remaining)
+        if suffix_remaining == 0:
+            break
+    suffix = "".join(reversed(suffix_parts))
+    return prefix + notice + suffix
+
+
+def _truncate_output(output: str) -> str:
+    """Clip an over-long code output to the fixed cap, keeping both ends."""
+    return _truncate_output_parts([output])
 
 
 def _run_async(coro):
@@ -211,18 +235,13 @@ class ModalSandboxExecutor(CodeExecutor):
             print("[CodeExecutor] Execution completed")
             print(f"[CodeExecutor] Success: {result.success}")
 
-            output = result.stdout or ""
+            output_parts = [result.stdout or ""]
 
-            print(f"[CodeExecutor] Stdout length: {len(output)} characters")
-
-            output = _truncate_output(output)
-            if len(output) != len(result.stdout or ""):
-                print(f"[CodeExecutor] Stdout truncated to {len(output)} characters")
+            print(f"[CodeExecutor] Stdout length: {len(output_parts[0])} characters")
 
             if result.stderr:
                 print(f"[CodeExecutor] Stderr: {result.stderr[:200]}")
-                stderr = _truncate_output(result.stderr)
-                output += f"\nSTDERR:\n{stderr}"
+                output_parts.append(f"\nSTDERR:\n{result.stderr}")
 
             if not result.success:
                 if result.error:
@@ -237,12 +256,11 @@ class ModalSandboxExecutor(CodeExecutor):
                     error_msg = f"Execution timed out after {self._timeout}s"
                 else:
                     error_msg = "Unknown error"
-                error_msg = _truncate_output(error_msg)
-                print(f"[CodeExecutor] Error: {error_msg}")
-                output += f"\nERROR: {error_msg}"
+                print(f"[CodeExecutor] Error: {error_msg[:200]}")
+                output_parts.append(f"\nERROR: {error_msg}")
 
-            if not output.strip():
-                output = "[CodeExecutor] Code executed but produced no output"
+            if not any(part.strip() for part in output_parts):
+                output_parts = ["[CodeExecutor] Code executed but produced no output"]
                 print("[CodeExecutor] Warning: No output produced")
 
             # Store rich output data dicts for image analysis
@@ -267,9 +285,12 @@ class ModalSandboxExecutor(CodeExecutor):
                             )
 
                 if image_analyses:
-                    output += "\n" + "\n".join(image_analyses)
+                    output_parts.append("\n" + "\n".join(image_analyses))
 
-            output = _truncate_output(output)
+            output_length = sum(len(part) for part in output_parts)
+            output = _truncate_output_parts(output_parts)
+            if len(output) != output_length:
+                print(f"[CodeExecutor] Output truncated to {len(output)} characters")
             return CodeResult(exit_code=0 if result.success else 1, output=output)
 
         except Exception as e:

--- a/packages/autodiscovery/tests/test_code_output_truncation.py
+++ b/packages/autodiscovery/tests/test_code_output_truncation.py
@@ -6,41 +6,32 @@ output OOM-kills the job (observed: 676 MB of stdout, container SIGKILLed).
 """
 
 import pytest
-
 from autodiscovery.agents import (
-    DEFAULT_MAX_CODE_OUTPUT_CHARS,
+    MAX_CODE_OUTPUT_CHARS,
     ModalSandboxExecutor,
     _truncate_output,
 )
 
 
 def test_short_output_is_returned_verbatim():
-    assert _truncate_output("hello", 100) == "hello"
+    assert _truncate_output("hello") == "hello"
 
 
 def test_output_at_the_limit_is_not_truncated():
-    output = "x" * 100
-    assert _truncate_output(output, 100) == output
-
-
-def test_non_positive_limit_disables_truncation():
-    output = "x" * 10_000
-    assert _truncate_output(output, 0) == output
-    assert _truncate_output(output, -1) == output
+    output = "x" * MAX_CODE_OUTPUT_CHARS
+    assert _truncate_output(output) == output
 
 
 def test_long_output_keeps_both_ends_and_reports_the_drop():
-    output = "H" * 5_000 + "M" * 90_000 + "T" * 5_000
-    truncated = _truncate_output(output, 10_000)
+    output = "H" * 10_000 + "M" * 80_000 + "T" * 10_000
+    truncated = _truncate_output(output)
 
     assert truncated.startswith("H")
     assert truncated.endswith("T")
     assert "output truncated" in truncated
-    # 90k characters omitted out of 100k, and the middle is gone.
-    assert "90000 of 100000 characters omitted" in truncated
+    assert "of 100000 characters omitted" in truncated
     assert "M" not in truncated
-    # The notice adds a bounded amount on top of the limit.
-    assert len(truncated) < 10_000 + 500
+    assert len(truncated) == MAX_CODE_OUTPUT_CHARS
 
 
 class _StubBackend:
@@ -71,11 +62,11 @@ def _executor(stdout, stderr="", **kwargs):
 def test_execute_code_blocks_caps_a_giant_stdout():
     from autogen.coding import CodeBlock
 
-    executor = _executor("x" * 5_000_000, max_output_chars=50_000)
+    executor = _executor("x" * 5_000_000)
     result = executor.execute_code_blocks([CodeBlock(code="print(dump)", language="python")])
 
     assert result.exit_code == 0
-    assert len(result.output) < 51_000
+    assert len(result.output) == MAX_CODE_OUTPUT_CHARS
     assert "output truncated" in result.output
 
 
@@ -88,26 +79,14 @@ def test_execute_code_blocks_leaves_a_small_stdout_alone():
     assert result.output == "42\n"
 
 
-def test_limit_comes_from_the_environment_then_the_default(monkeypatch):
-    monkeypatch.setenv("AUTODISCOVERY_MAX_CODE_OUTPUT_CHARS", "1234")
-    assert _executor("")._max_output_chars == 1234
-
-    monkeypatch.delenv("AUTODISCOVERY_MAX_CODE_OUTPUT_CHARS")
-    assert _executor("")._max_output_chars == DEFAULT_MAX_CODE_OUTPUT_CHARS
-
-    # An explicit argument wins over the environment.
-    monkeypatch.setenv("AUTODISCOVERY_MAX_CODE_OUTPUT_CHARS", "1234")
-    assert _executor("", max_output_chars=99)._max_output_chars == 99
-
-
 def test_stderr_is_capped_too():
     from autogen.coding import CodeBlock
 
-    executor = _executor("ok\n", stderr="e" * 1_000_000, max_output_chars=20_000)
+    executor = _executor("ok\n", stderr="e" * 1_000_000)
     result = executor.execute_code_blocks([CodeBlock(code="pass", language="python")])
 
     assert result.output.startswith("ok\n")
-    assert len(result.output) < 41_000
+    assert len(result.output) == MAX_CODE_OUTPUT_CHARS
     assert "output truncated" in result.output
 
 

--- a/packages/autodiscovery/tests/test_code_output_truncation.py
+++ b/packages/autodiscovery/tests/test_code_output_truncation.py
@@ -88,6 +88,7 @@ def test_stderr_is_capped_too():
     assert result.output.startswith("ok\n")
     assert len(result.output) == MAX_CODE_OUTPUT_CHARS
     assert "output truncated" in result.output
+    assert "of 1000012 characters omitted" in result.output
 
 
 if __name__ == "__main__":

--- a/packages/autodiscovery/tests/test_code_output_truncation.py
+++ b/packages/autodiscovery/tests/test_code_output_truncation.py
@@ -5,6 +5,7 @@ chat message that is re-serialized into every later LLM request, so an uncapped
 output OOM-kills the job (observed: 676 MB of stdout, container SIGKILLed).
 """
 
+import autodiscovery.agents as agents
 import pytest
 from autodiscovery.agents import (
     MAX_CODE_OUTPUT_CHARS,
@@ -20,6 +21,25 @@ def test_short_output_is_returned_verbatim():
 def test_output_at_the_limit_is_not_truncated():
     output = "x" * MAX_CODE_OUTPUT_CHARS
     assert _truncate_output(output) == output
+
+
+def test_tiny_fixed_cap_cannot_leak_the_full_output(monkeypatch):
+    monkeypatch.setattr(agents, "MAX_CODE_OUTPUT_CHARS", 32)
+
+    truncated = _truncate_output("x" * 1_000)
+
+    assert len(truncated) == 32
+    assert "output truncated" in truncated
+
+
+def test_one_character_over_limit_reports_exact_omission():
+    output = "x" * (MAX_CODE_OUTPUT_CHARS + 1)
+
+    truncated = _truncate_output(output)
+
+    retained = truncated.count("x")
+    assert len(truncated) == MAX_CODE_OUTPUT_CHARS
+    assert f"output truncated: {len(output) - retained} of {len(output)}" in truncated
 
 
 def test_long_output_keeps_both_ends_and_reports_the_drop():

--- a/packages/autodiscovery/tests/test_code_output_truncation.py
+++ b/packages/autodiscovery/tests/test_code_output_truncation.py
@@ -1,0 +1,115 @@
+"""Tests for the cap on code-executor output size.
+
+Generated code regularly prints an entire dataset; the executor's output becomes a
+chat message that is re-serialized into every later LLM request, so an uncapped
+output OOM-kills the job (observed: 676 MB of stdout, container SIGKILLed).
+"""
+
+import pytest
+
+from autodiscovery.agents import (
+    DEFAULT_MAX_CODE_OUTPUT_CHARS,
+    ModalSandboxExecutor,
+    _truncate_output,
+)
+
+
+def test_short_output_is_returned_verbatim():
+    assert _truncate_output("hello", 100) == "hello"
+
+
+def test_output_at_the_limit_is_not_truncated():
+    output = "x" * 100
+    assert _truncate_output(output, 100) == output
+
+
+def test_non_positive_limit_disables_truncation():
+    output = "x" * 10_000
+    assert _truncate_output(output, 0) == output
+    assert _truncate_output(output, -1) == output
+
+
+def test_long_output_keeps_both_ends_and_reports_the_drop():
+    output = "H" * 5_000 + "M" * 90_000 + "T" * 5_000
+    truncated = _truncate_output(output, 10_000)
+
+    assert truncated.startswith("H")
+    assert truncated.endswith("T")
+    assert "output truncated" in truncated
+    # 90k characters omitted out of 100k, and the middle is gone.
+    assert "90000 of 100000 characters omitted" in truncated
+    assert "M" not in truncated
+    # The notice adds a bounded amount on top of the limit.
+    assert len(truncated) < 10_000 + 500
+
+
+class _StubBackend:
+    """Sandbox backend returning a canned result, mirroring asta_sandbox's shape."""
+
+    def __init__(self, stdout, stderr=""):
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def run_code(self, code, timeout_seconds=None):
+        from asta_sandbox import ExecutionResult
+
+        return ExecutionResult(
+            stdout=self._stdout,
+            stderr=self._stderr,
+            success=True,
+            rich_outputs=(),
+            error=None,
+        )
+
+
+def _executor(stdout, stderr="", **kwargs):
+    return ModalSandboxExecutor(
+        _StubBackend(stdout, stderr), vision_model="vertex_ai/gemini-3.7-flash", **kwargs
+    )
+
+
+def test_execute_code_blocks_caps_a_giant_stdout():
+    from autogen.coding import CodeBlock
+
+    executor = _executor("x" * 5_000_000, max_output_chars=50_000)
+    result = executor.execute_code_blocks([CodeBlock(code="print(dump)", language="python")])
+
+    assert result.exit_code == 0
+    assert len(result.output) < 51_000
+    assert "output truncated" in result.output
+
+
+def test_execute_code_blocks_leaves_a_small_stdout_alone():
+    from autogen.coding import CodeBlock
+
+    executor = _executor("42\n")
+    result = executor.execute_code_blocks([CodeBlock(code="print(42)", language="python")])
+
+    assert result.output == "42\n"
+
+
+def test_limit_comes_from_the_environment_then_the_default(monkeypatch):
+    monkeypatch.setenv("AUTODISCOVERY_MAX_CODE_OUTPUT_CHARS", "1234")
+    assert _executor("")._max_output_chars == 1234
+
+    monkeypatch.delenv("AUTODISCOVERY_MAX_CODE_OUTPUT_CHARS")
+    assert _executor("")._max_output_chars == DEFAULT_MAX_CODE_OUTPUT_CHARS
+
+    # An explicit argument wins over the environment.
+    monkeypatch.setenv("AUTODISCOVERY_MAX_CODE_OUTPUT_CHARS", "1234")
+    assert _executor("", max_output_chars=99)._max_output_chars == 99
+
+
+def test_stderr_is_capped_too():
+    from autogen.coding import CodeBlock
+
+    executor = _executor("ok\n", stderr="e" * 1_000_000, max_output_chars=20_000)
+    result = executor.execute_code_blocks([CodeBlock(code="pass", language="python")])
+
+    assert result.output.startswith("ok\n")
+    assert len(result.output) < 41_000
+    assert "output truncated" in result.output
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
The prod AutoDiscovery Cloud Run job was SIGKILLed (`exit(137)`) twice on 2026-09-07, ~5 minutes apart. Both executions died on the turn right after a generated code block returned an enormous stdout — one logged `[CodeExecutor] Stdout length: 675997343 characters` (676 MB) after the agent read a raw `.sql` dump and printed its table lines. This is not rare: executions on 2026-09-08 logged 160 MB and 82 MB outputs from the same pattern.

`ModalSandboxExecutor.execute_code_blocks` returned `result.stdout` uncapped. That string becomes a `CodeResult.output`, which becomes a group-chat message, which is then re-serialized into every subsequent LLM request — so one 676 MB print is copied many times over and the container is killed on the next speaker.

This caps the complete code result at a fixed 20,000 characters, keeping the head and tail (headers/schema at the front, final result or traceback at the back) and dropping the middle. Twenty thousand characters is roughly 5,000 LLM tokens and leaves about 10,000 characters for each end before the elision notice—enough for many tabular rows or a typical traceback without letting one tool result dominate future model requests. The elision notice counts toward the cap, states how many characters were omitted, and tells the agent to aggregate, sample, or write to a file instead.

Tests in `packages/autodiscovery/tests/test_code_output_truncation.py` cover the exact boundary, head/tail retention, the fixed total ceiling across stdout and stderr, and a 5 MB stdout going through `execute_code_blocks`.

Not addressed here: the giant string is still materialized once inside the executor before the cap applies, so a single output large enough to exhaust memory on its own would still fail. Capping at the sandbox boundary (`asta-sandbox`) would close that; this change removes the amplification, which is what actually killed the job.

Related: #79 (unbounded log volume from a spinning `run_mcts`) is a separate symptom of the same missing-output-bounds theme.

Suggested-by: @dirkraft
